### PR TITLE
Extract tag from helm deployment

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,7 +45,7 @@ test workflow.  Clone this repository, and from its root directory, run:
 #
 # Add binary environment and create two test functions on your Fission setup:
 #
-fission env create --name binary --image fission/binary-env:v0.3.0
+fission env create --name binary --image fission/binary-env
 fission function create --name whalesay --env binary --deploy examples/whales/whalesay.sh
 fission function create --name fortune --env binary --deploy examples/whales/fortune.sh
 
@@ -58,7 +58,7 @@ fission function create --name fortunewhale --env workflow --src examples/whales
 #
 # Map an HTTP GET to your new workflow function:
 #
-$ fission route create --method GET --url /fortunewhale --function fortunewhale
+fission route create --method GET --url /fortunewhale --function fortunewhale
 
 #
 # Invoke the workflow with an HTTP request:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See the [docs](./Docs) for a more extensive, in-depth overview of the system.
 #
 # Add binary environment and create two test function on your Fission setup 
 #
-fission env create --name binary --image fission/binary-env:v0.3.0
+fission env create --name binary --image fission/binary-env
 fission function create --name whalesay --env binary --deploy examples/whales/whalesay.sh
 fission function create --name fortune --env binary --deploy examples/whales/fortune.sh
 
@@ -123,7 +123,7 @@ fission function create --name fortunewhale --env workflow --src examples/whales
 #
 # Map a HTTP GET to your new workflow function
 #
-$ fission route create --method GET --url /fortunewhale --function fortunewhale
+fission route create --method GET --url /fortunewhale --function fortunewhale
 
 #
 # Invoke the workflow with an HTTP request

--- a/charts/fission-workflows/templates/NOTES.txt
+++ b/charts/fission-workflows/templates/NOTES.txt
@@ -6,7 +6,7 @@ Usage:
 https://raw.githubusercontent.com/fission/fission-workflows/master/examples/whales/fortune.sh > fortune.sh
 https://raw.githubusercontent.com/fission/fission-workflows/master/examples/whales/whalesay.sh > whalesay.sh
 
-fission env create --name binary --image fission/binary-env:0.3.0
+fission env create --name binary --image fission/binary-env
 fission fn create --name whalesay --env binary --deploy ./whalesay.sh
 fission fn create --name fortune --env binary --deploy ./fortune.sh
 

--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: workflows-apiserver
         image: "{{ .Values.bundleImage }}:{{.Values.tag}}"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-workflows-bundle"]
         args: [
         # Only run apiserver components

--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: workflows-apiserver
-  namespace: fission
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
@@ -15,7 +14,7 @@ spec:
     spec:
       containers:
       - name: workflows-apiserver
-        image: {{ .Values.bundleImage }}
+        image: "{{ .Values.bundleImage }}:{{.Values.tag}}"
         imagePullPolicy: IfNotPresent
         command: ["/fission-workflows-bundle"]
         args: [
@@ -53,6 +52,7 @@ spec:
     svc: workflows-apiserver
 ---
 {{ end }}
+# Workflow Engine is managed like any other environment in Fission
 apiVersion: fission.io/v1
 kind: Environment
 metadata:
@@ -62,8 +62,8 @@ spec:
   version: 2
   runtime:
   # TODO Add environment variables for environment once supported by Fission
-    image: "{{ .Values.envImage }}"
+    image: "{{ .Values.envImage }}:{{.Values.tag}}"
   builder:
-    image: "{{ .Values.buildEnvImage }}"
+    image: "{{ .Values.buildEnvImage }}:{{.Values.tag}}"
     command: "defaultBuild"
   allowedFunctionsPerContainer: infinite

--- a/charts/fission-workflows/values.yaml
+++ b/charts/fission-workflows/values.yaml
@@ -3,13 +3,15 @@
 #
 
 # Bundle image
-bundleImage: fission/fission-workflows-bundle:0.1.2
+bundleImage: fission/fission-workflows-bundle
 
 # Image of the Fission environment for Fission Workflows
-envImage: fission/workflow-env:0.1.2
+envImage: fission/workflow-env
 
 # Image of the Fission build environment for Fission Workflows
-buildEnvImage: fission/workflow-build-env:0.1.2
+buildEnvImage: fission/workflow-build-env
+
+tag: 0.1.2
 
 # Deploy optional Workflow api-server?
 apiserver: true

--- a/charts/fission-workflows/values.yaml
+++ b/charts/fission-workflows/values.yaml
@@ -13,6 +13,8 @@ buildEnvImage: fission/workflow-build-env
 
 tag: 0.1.2
 
+pullPolicy: IfNotPresent
+
 # Deploy optional Workflow api-server?
 apiserver: true
 

--- a/compiling.md
+++ b/compiling.md
@@ -1,5 +1,9 @@
 # Compiling
 
+*You only need to do this if you're making Fission Workflows changes; if you're
+just deploying Fission Workflows, use the helm chart which points to prebuilt
+images by default.*
+
 ## Requirements
 - go >1.8
 - docker
@@ -20,6 +24,12 @@ eval $(minikube docker-env)
 
 # Build the docker image
 bash ./docker.sh
+```
+
+To deploy your locally compiled version. As of writing Fission Workflows, requires fission to be installed 
+in the fission namespace.
+```bash
+helm install --set "tag=latest" --namespace fission charts/fission-workflows
 ```
 
 ### CLI


### PR DESCRIPTION
This allows a bit more convenient deployment of locally compiled instances. (see the update to compiling.md for example)