### PR TITLE
Update Fission dependency

### DIFF
--- a/build/docker.sh
+++ b/build/docker.sh
@@ -3,10 +3,19 @@
 set -ex
 
 #
-# Builds all docker images
+# Builds all docker images. Usage docker.sh [<repo>] [<tag>]
 #
-IMAGE_VERSION=0.1.2
-IMAGE_ORG=fission
+BUILD_ROOT=$(dirname $0)
+
+IMAGE_REPO=$1
+if [ -z "$IMAGE_REPO" ]; then
+    IMAGE_TAG=fission
+fi
+
+IMAGE_TAG=$2
+if [ -z "$IMAGE_TAG" ]; then
+    IMAGE_TAG=latest
+fi
 
 # Check preconditions
 if [ ! -f ./fission-workflows-bundle ]; then
@@ -20,16 +29,16 @@ if [ ! -f ./wfcli ]; then
 fi
 
 # Prepare fs
-rm -f bundle/fission-workflows-bundle
-rm -f env/fission-workflows-bundle
-rm -f build-env/wfcli
+rm -f ${BUILD_ROOT}/bundle/fission-workflows-bundle
+rm -f ${BUILD_ROOT}/env/fission-workflows-bundle
+rm -f ${BUILD_ROOT}/build-env/wfcli
 chmod +x fission-workflows-bundle
 chmod +x wfcli
-yes | cp fission-workflows-bundle env/
-yes | cp fission-workflows-bundle bundle/
-yes | cp wfcli build-env/
+yes | cp fission-workflows-bundle ${BUILD_ROOT}/env/
+yes | cp fission-workflows-bundle ${BUILD_ROOT}/bundle/
+yes | cp wfcli ${BUILD_ROOT}/build-env/
 
 # Build images
-docker build --tag="${IMAGE_ORG}/fission-workflows-bundle:${IMAGE_VERSION}" bundle/
-docker build --tag="${IMAGE_ORG}/workflow-env:${IMAGE_VERSION}" env/
-docker build --tag="${IMAGE_ORG}/workflow-build-env:${IMAGE_VERSION}" build-env/
+docker build --tag="${IMAGE_REPO}/fission-workflows-bundle:${IMAGE_TAG}" ${BUILD_ROOT}/bundle/
+docker build --tag="${IMAGE_REPO}/workflow-env:${IMAGE_TAG}" ${BUILD_ROOT}/env/
+docker build --tag="${IMAGE_REPO}/workflow-build-env:${IMAGE_TAG}" ${BUILD_ROOT}/build-env/

--- a/build/env/Dockerfile
+++ b/build/env/Dockerfile
@@ -5,7 +5,7 @@ ADD fission-workflows-bundle /
 EXPOSE 8888
 
 ENV FNENV_FISSION_CONTROLLER http://controller.fission
-ENV FNENV_FISSION_POOLMGR http://poolmgr.fission
+ENV FNENV_FISSION_EXECUTOR http://executor.fission
 ENV ES_NATS_URL nats://defaultFissionAuthToken@nats-streaming.fission:4222
 ENV ES_NATS_CLUSTER fissionMQTrigger
 

--- a/charts/fission-workflows/Chart.yaml
+++ b/charts/fission-workflows/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: fission-workflows
-version: 0.1.2
-appVersion: 0.1.2
+version: 0.1.3
+appVersion: 0.1.3
 description: Fission Workflows is a fast workflow engine for serverless functions on Kubernetes
 keywords:
 - fission

--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -31,8 +31,8 @@ spec:
           value: nats://{{ .Values.nats.authToken }}@{{ .Values.nats.location }}
         - name: ES_NATS_CLUSTER
           value: "{{ .Values.nats.cluster }}"
-        - name: FNENV_FISSION_POOLMGR
-          value: "{{ .Values.fnenv.fission.poolmgr }}"
+        - name: FNENV_FISSION_EXECUTOR
+          value: "{{ .Values.fnenv.fission.executor }}"
         - name: FNENV_FISSION_CONTROLLER
           value: "{{ .Values.fnenv.fission.controller }}"
 ---

--- a/charts/fission-workflows/values.yaml
+++ b/charts/fission-workflows/values.yaml
@@ -11,7 +11,7 @@ envImage: fission/workflow-env
 # Image of the Fission build environment for Fission Workflows
 buildEnvImage: fission/workflow-build-env
 
-tag: 0.1.2
+tag: 0.1.3
 
 pullPolicy: IfNotPresent
 

--- a/charts/fission-workflows/values.yaml
+++ b/charts/fission-workflows/values.yaml
@@ -22,7 +22,7 @@ apiserver: true
 fnenv:
   fission:
     controller: http://controller.fission
-    poolmgr: http://poolmgr.fission
+    executor: http://executor.fission
 
 # Message queue config
 nats:

--- a/cmd/fission-workflows-bundle/bundle/bundle.go
+++ b/cmd/fission-workflows-bundle/bundle/bundle.go
@@ -29,7 +29,7 @@ import (
 	"github.com/fission/fission-workflows/pkg/util/pubsub"
 	"github.com/fission/fission-workflows/pkg/version"
 	controllerc "github.com/fission/fission/controller/client"
-	poolmgrc "github.com/fission/fission/poolmgr/client"
+	executor "github.com/fission/fission/executor/client"
 	"github.com/gorilla/handlers"
 	grpcruntime "github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/nats-io/go-nats-streaming"
@@ -56,8 +56,8 @@ type Options struct {
 }
 
 type FissionOptions struct {
-	PoolmgrAddr    string
-	ControllerAddr string
+	ExecutorAddress string
+	ControllerAddr  string
 }
 
 type NatsOptions struct {
@@ -98,7 +98,7 @@ func Run(ctx context.Context, opts *Options) error {
 		resolvers["internal"] = setupInternalFunctionRuntime()
 	}
 	if opts.Fission != nil {
-		runtimes["fission"] = setupFissionFunctionRuntime(opts.Fission.PoolmgrAddr)
+		runtimes["fission"] = setupFissionFunctionRuntime(opts.Fission.ExecutorAddress)
 		resolvers["fission"] = setupFissionFunctionResolver(opts.Fission.ControllerAddr)
 	}
 
@@ -195,9 +195,9 @@ func setupInternalFunctionRuntime() *native.FunctionEnv {
 	return native.NewFunctionEnv(builtin.DefaultBuiltinFunctions)
 }
 
-func setupFissionFunctionRuntime(poolmgrAddr string) *fission.FunctionEnv {
-	poolmgrClient := poolmgrc.MakeClient(poolmgrAddr)
-	return fission.NewFunctionEnv(poolmgrClient)
+func setupFissionFunctionRuntime(executorAddr string) *fission.FunctionEnv {
+	client := executor.MakeClient(executorAddr)
+	return fission.NewFunctionEnv(client)
 }
 
 func setupFissionFunctionResolver(controllerAddr string) *fission.Resolver {

--- a/cmd/fission-workflows-bundle/main.go
+++ b/cmd/fission-workflows-bundle/main.go
@@ -50,8 +50,8 @@ func parseFissionOptions(c *cli.Context) *bundle.FissionOptions {
 	}
 
 	return &bundle.FissionOptions{
-		PoolmgrAddr:    c.String("fission-poolmgr"),
-		ControllerAddr: c.String("fission-controller"),
+		ExecutorAddress: c.String("fission-executor"),
+		ControllerAddr:  c.String("fission-controller"),
 	}
 }
 
@@ -112,10 +112,10 @@ func createCli() *cli.App {
 			Usage: "Use Fission as a function environment",
 		},
 		cli.StringFlag{
-			Name:   "fission-poolmgr",
-			Usage:  "Address of the poolmgr",
-			Value:  "http://poolmgr.fission",
-			EnvVar: "FNENV_FISSION_POOLMGR",
+			Name:   "fission-executor",
+			Usage:  "Address of the fission executor",
+			Value:  "http://executor.fission",
+			EnvVar: "FNENV_FISSION_EXECUTOR",
 		},
 		cli.StringFlag{
 			Name:   "fission-controller",

--- a/cmd/wfcli/main.go
+++ b/cmd/wfcli/main.go
@@ -45,7 +45,7 @@ func main() {
 		{
 			Name:    "status",
 			Aliases: []string{"s"},
-			Usage:   "Check cluster",
+			Usage:   "Check cluster status",
 			Action: func(c *cli.Context) error {
 				u := parseUrl(c.GlobalString("url"))
 				client := createTransportClient(u)

--- a/compiling.md
+++ b/compiling.md
@@ -26,8 +26,8 @@ eval $(minikube docker-env)
 bash ./docker.sh
 ```
 
-To deploy your locally compiled version. As of writing Fission Workflows, requires fission to be installed 
-in the fission namespace.
+To deploy your locally compiled version. **As of writing Fission Workflows, requires fission to be installed 
+in the fission namespace.**
 ```bash
 helm install --set "tag=latest" --namespace fission charts/fission-workflows
 ```

--- a/glide.lock
+++ b/glide.lock
@@ -1,44 +1,45 @@
-hash: 863a199251414af3e7e772b08ad8123799eb145fe9a039652e7777930bda8b1d
-updated: 2017-09-28T18:45:33.89626923-07:00
+hash: 21e3ba2937297ef8f9bbba49b9b9146886f370ee0f285852c7b18333dbb7e2bd
+updated: 2017-11-21T14:28:06.375434+01:00
 imports:
+- name: cloud.google.com/go
+  version: 3b1ae45394a234c385be014e9a488f2bb6eef821
+  subpackages:
+  - compute/metadata
+  - internal
 - name: github.com/asaskevich/govalidator
   version: 6fcd5b427f532a5d13738b27415e00a49e36ceef
-- name: github.com/blang/semver
-  version: 60ec3488bfea7cca02b021d106d9911120d25fe9
-- name: github.com/coreos/go-oidc
-  version: 16c5ecc505f1efa0fe4685826fd9962c4d137e87
+- name: github.com/Azure/go-autorest
+  version: 58f6f26e200fa5dfb40c9cd1c83f3e2c860d779d
   subpackages:
-  - http
-  - jose
-  - key
-  - oauth2
-  - oidc
-- name: github.com/coreos/pkg
-  version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
-  subpackages:
-  - health
-  - httputil
-  - timeutil
+  - autorest
+  - autorest/adal
+  - autorest/azure
+  - autorest/date
 - name: github.com/davecgh/go-spew
-  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/dgrijalva/jwt-go
+  version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/docker/distribution
-  version: 6e62b398420f8c0444e34e8a69a350c139f65956
+  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
   subpackages:
   - digest
   - reference
 - name: github.com/emicklei/go-restful
-  version: 3d66f886316ac990eb502aaa89ea38546420b8b7
+  version: ff4f55a206334ef123e4f79bbf348980da81ca46
   subpackages:
   - log
-  - swagger
+- name: github.com/emicklei/go-restful-swagger12
+  version: dcef7f55730566d41eae5db10e7d6981829720f6
 - name: github.com/fission/fission
   version: b2678783b63b4dccda8e6b02ca1adf292e1bb183
   subpackages:
+  - cache
   - controller/client
+  - crd
   - executor/client
-  - tpr
+  - router
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-openapi/analysis
@@ -48,7 +49,7 @@ imports:
 - name: github.com/go-openapi/jsonpointer
   version: 8d96a2dc61536b690bd36b2e9df0b3c0b62825b2
 - name: github.com/go-openapi/jsonreference
-  version: 36d33bfe519efae5632669801b180bf1a245da3b
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
 - name: github.com/go-openapi/loads
   version: 315567415dfd74b651f7a62cabfc82a57ed7b9ad
 - name: github.com/go-openapi/runtime
@@ -68,7 +69,7 @@ imports:
   subpackages:
   - base64vlq
 - name: github.com/gogo/protobuf
-  version: 100ba4e885062801d56799d78530b73b178a78f3
+  version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
   subpackages:
   - gogoproto
   - jsonpb
@@ -77,7 +78,7 @@ imports:
   - sortkeys
   - types
 - name: github.com/golang/glog
-  version: 23def4e6c14b4da8ac2ed8007337bc5eb5007998
+  version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/protobuf
   version: 0a4f71a498b7c4812f64969510bcb4eca251e33a
   subpackages:
@@ -91,27 +92,31 @@ imports:
   - ptypes/struct
   - ptypes/timestamp
 - name: github.com/google/gofuzz
-  version: fd52762d25a41827db7ef64c43756fd4b9f7e382
+  version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
+- name: github.com/gorilla/context
+  version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/handlers
-  version: a4043c62cc2329bacda331d33fc908ab11ef0ec3
+  version: 90663712d74cb411cbef281bc1e08c19d1a76145
 - name: github.com/gorilla/mux
-  version: 24fca303ac6da784b9e8269f724ddeb0b2eea5e7
+  version: 7f08801859139f86dfafd1c296e2cba9a80d292e
 - name: github.com/grpc-ecosystem/grpc-gateway
   version: f2862b476edcef83412c7af8687c9cd8e4097c0f
   subpackages:
   - runtime
   - runtime/internal
   - utilities
+- name: github.com/hashicorp/golang-lru
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  subpackages:
+  - simplelru
 - name: github.com/howeyc/gopass
   version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/imdario/mergo
-  version: e3000cb3d28c72b837601cac94debd91032d19fe
-- name: github.com/jonboulle/clockwork
-  version: 2eee05ed794112d45db504eb05aa693efd2b8b09
+  version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/juju/ratelimit
-  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+  version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
 - name: github.com/mailru/easyjson
-  version: 159cdb893c982e3d1bc6450322fedd514f9c9de3
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
   subpackages:
   - buffer
   - jlexer
@@ -129,8 +134,6 @@ imports:
   - pb
 - name: github.com/nats-io/nuid
   version: 289cccf02c178dc782430d534e3c1f5b72af807f
-- name: github.com/pborman/uuid
-  version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
@@ -150,15 +153,15 @@ imports:
 - name: github.com/sirupsen/logrus
   version: 68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a
 - name: github.com/spf13/pflag
-  version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5
+  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
-  version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
+  version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
 - name: github.com/urfave/cli
   version: cfb38830724cc34fedffe9a2a29fb54fa9169cd1
 - name: golang.org/x/crypto
-  version: 9477e0b78b9ac3d0b03822fd95422e2fe07627cd
+  version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
   - ssh/terminal
 - name: golang.org/x/net
@@ -173,7 +176,7 @@ imports:
   - lex/httplex
   - trace
 - name: golang.org/x/oauth2
-  version: 045497edb6234273d67dbc25da3f2ddbc4c4cacf
+  version: a6bd8cefa1811bd24b86f8902872e4e8225f74c4
   subpackages:
   - google
   - internal
@@ -184,10 +187,9 @@ imports:
   subpackages:
   - unix
 - name: golang.org/x/text
-  version: a263ba8db058568bb9beba166777d9c9dbe75d68
+  version: 88f656faf3f37f690df1a32515b479415e1a6769
   subpackages:
   - cases
-  - internal
   - internal/tag
   - language
   - runes
@@ -209,13 +211,6 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
-- name: google.golang.org/cloud
-  version: 975617b05ea8a58727e6c1a06b6161ff4185a9f2
-  subpackages:
-  - compute/metadata
-  - internal
-  - internal/opts
-  - storage
 - name: google.golang.org/genproto
   version: 595979c8a7bf586b2d293fb42246bf91a0b893d9
   subpackages:
@@ -248,116 +243,147 @@ imports:
   version: 9753370bfb4cbdcab8e6ecd5551ffe8684e3e5b5
 - name: gopkg.in/yaml.v2
   version: bef53efd0c76e49e6de55ead051f886bea7e9420
-- name: k8s.io/client-go
-  version: 843f7c4f28b1f647f664f883697107d5c02c5acc
+- name: k8s.io/apiextensions-apiserver
+  version: fcd622fe88a4a6efcb5aea9e94ee87324ac1b036
   subpackages:
-  - 1.5/discovery
-  - 1.5/kubernetes
-  - 1.5/kubernetes/typed/apps/v1alpha1
-  - 1.5/kubernetes/typed/authentication/v1beta1
-  - 1.5/kubernetes/typed/authorization/v1beta1
-  - 1.5/kubernetes/typed/autoscaling/v1
-  - 1.5/kubernetes/typed/batch/v1
-  - 1.5/kubernetes/typed/certificates/v1alpha1
-  - 1.5/kubernetes/typed/core/v1
-  - 1.5/kubernetes/typed/extensions/v1beta1
-  - 1.5/kubernetes/typed/policy/v1alpha1
-  - 1.5/kubernetes/typed/rbac/v1alpha1
-  - 1.5/kubernetes/typed/storage/v1beta1
-  - 1.5/pkg/api
-  - 1.5/pkg/api/errors
-  - 1.5/pkg/api/install
-  - 1.5/pkg/api/meta
-  - 1.5/pkg/api/meta/metatypes
-  - 1.5/pkg/api/resource
-  - 1.5/pkg/api/unversioned
-  - 1.5/pkg/api/v1
-  - 1.5/pkg/api/validation/path
-  - 1.5/pkg/apimachinery
-  - 1.5/pkg/apimachinery/announced
-  - 1.5/pkg/apimachinery/registered
-  - 1.5/pkg/apis/apps
-  - 1.5/pkg/apis/apps/install
-  - 1.5/pkg/apis/apps/v1alpha1
-  - 1.5/pkg/apis/authentication
-  - 1.5/pkg/apis/authentication/install
-  - 1.5/pkg/apis/authentication/v1beta1
-  - 1.5/pkg/apis/authorization
-  - 1.5/pkg/apis/authorization/install
-  - 1.5/pkg/apis/authorization/v1beta1
-  - 1.5/pkg/apis/autoscaling
-  - 1.5/pkg/apis/autoscaling/install
-  - 1.5/pkg/apis/autoscaling/v1
-  - 1.5/pkg/apis/batch
-  - 1.5/pkg/apis/batch/install
-  - 1.5/pkg/apis/batch/v1
-  - 1.5/pkg/apis/batch/v2alpha1
-  - 1.5/pkg/apis/certificates
-  - 1.5/pkg/apis/certificates/install
-  - 1.5/pkg/apis/certificates/v1alpha1
-  - 1.5/pkg/apis/extensions
-  - 1.5/pkg/apis/extensions/install
-  - 1.5/pkg/apis/extensions/v1beta1
-  - 1.5/pkg/apis/policy
-  - 1.5/pkg/apis/policy/install
-  - 1.5/pkg/apis/policy/v1alpha1
-  - 1.5/pkg/apis/rbac
-  - 1.5/pkg/apis/rbac/install
-  - 1.5/pkg/apis/rbac/v1alpha1
-  - 1.5/pkg/apis/storage
-  - 1.5/pkg/apis/storage/install
-  - 1.5/pkg/apis/storage/v1beta1
-  - 1.5/pkg/auth/user
-  - 1.5/pkg/conversion
-  - 1.5/pkg/conversion/queryparams
-  - 1.5/pkg/fields
-  - 1.5/pkg/genericapiserver/openapi/common
-  - 1.5/pkg/labels
-  - 1.5/pkg/runtime
-  - 1.5/pkg/runtime/serializer
-  - 1.5/pkg/runtime/serializer/json
-  - 1.5/pkg/runtime/serializer/protobuf
-  - 1.5/pkg/runtime/serializer/recognizer
-  - 1.5/pkg/runtime/serializer/streaming
-  - 1.5/pkg/runtime/serializer/versioning
-  - 1.5/pkg/selection
-  - 1.5/pkg/third_party/forked/golang/reflect
-  - 1.5/pkg/types
-  - 1.5/pkg/util
-  - 1.5/pkg/util/cert
-  - 1.5/pkg/util/clock
-  - 1.5/pkg/util/errors
-  - 1.5/pkg/util/flowcontrol
-  - 1.5/pkg/util/framer
-  - 1.5/pkg/util/homedir
-  - 1.5/pkg/util/integer
-  - 1.5/pkg/util/intstr
-  - 1.5/pkg/util/json
-  - 1.5/pkg/util/labels
-  - 1.5/pkg/util/net
-  - 1.5/pkg/util/parsers
-  - 1.5/pkg/util/rand
-  - 1.5/pkg/util/runtime
-  - 1.5/pkg/util/sets
-  - 1.5/pkg/util/uuid
-  - 1.5/pkg/util/validation
-  - 1.5/pkg/util/validation/field
-  - 1.5/pkg/util/wait
-  - 1.5/pkg/util/yaml
-  - 1.5/pkg/version
-  - 1.5/pkg/watch
-  - 1.5/pkg/watch/versioned
-  - 1.5/plugin/pkg/client/auth
-  - 1.5/plugin/pkg/client/auth/gcp
-  - 1.5/plugin/pkg/client/auth/oidc
-  - 1.5/rest
-  - 1.5/tools/auth
-  - 1.5/tools/clientcmd
-  - 1.5/tools/clientcmd/api
-  - 1.5/tools/clientcmd/api/latest
-  - 1.5/tools/clientcmd/api/v1
-  - 1.5/tools/metrics
-  - 1.5/transport
+  - pkg/apis/apiextensions
+  - pkg/apis/apiextensions/v1beta1
+  - pkg/client/clientset/clientset
+  - pkg/client/clientset/clientset/scheme
+  - pkg/client/clientset/clientset/typed/apiextensions/v1beta1
+- name: k8s.io/apimachinery
+  version: 8ab5f3d8a330c2e9baaf84e39042db8d49034ae2
+  subpackages:
+  - pkg/api/equality
+  - pkg/api/errors
+  - pkg/api/meta
+  - pkg/api/resource
+  - pkg/apimachinery
+  - pkg/apimachinery/announced
+  - pkg/apimachinery/registered
+  - pkg/apis/meta/v1
+  - pkg/apis/meta/v1/unstructured
+  - pkg/apis/meta/v1alpha1
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/conversion/unstructured
+  - pkg/fields
+  - pkg/labels
+  - pkg/openapi
+  - pkg/runtime
+  - pkg/runtime/schema
+  - pkg/runtime/serializer
+  - pkg/runtime/serializer/json
+  - pkg/runtime/serializer/protobuf
+  - pkg/runtime/serializer/recognizer
+  - pkg/runtime/serializer/streaming
+  - pkg/runtime/serializer/versioning
+  - pkg/selection
+  - pkg/types
+  - pkg/util/cache
+  - pkg/util/clock
+  - pkg/util/diff
+  - pkg/util/errors
+  - pkg/util/framer
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/net
+  - pkg/util/rand
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/util/wait
+  - pkg/util/yaml
+  - pkg/version
+  - pkg/watch
+  - third_party/forked/golang/reflect
+- name: k8s.io/client-go
+  version: d92e8497f71b7b4e0494e5bd204b48d34bd6f254
+  subpackages:
+  - discovery
+  - kubernetes
+  - kubernetes/scheme
+  - kubernetes/typed/admissionregistration/v1alpha1
+  - kubernetes/typed/apps/v1beta1
+  - kubernetes/typed/authentication/v1
+  - kubernetes/typed/authentication/v1beta1
+  - kubernetes/typed/authorization/v1
+  - kubernetes/typed/authorization/v1beta1
+  - kubernetes/typed/autoscaling/v1
+  - kubernetes/typed/autoscaling/v2alpha1
+  - kubernetes/typed/batch/v1
+  - kubernetes/typed/batch/v2alpha1
+  - kubernetes/typed/certificates/v1beta1
+  - kubernetes/typed/core/v1
+  - kubernetes/typed/extensions/v1beta1
+  - kubernetes/typed/networking/v1
+  - kubernetes/typed/policy/v1beta1
+  - kubernetes/typed/rbac/v1alpha1
+  - kubernetes/typed/rbac/v1beta1
+  - kubernetes/typed/settings/v1alpha1
+  - kubernetes/typed/storage/v1
+  - kubernetes/typed/storage/v1beta1
+  - pkg/api
+  - pkg/api/v1
+  - pkg/api/v1/ref
+  - pkg/apis/admissionregistration
+  - pkg/apis/admissionregistration/v1alpha1
+  - pkg/apis/apps
+  - pkg/apis/apps/v1beta1
+  - pkg/apis/authentication
+  - pkg/apis/authentication/v1
+  - pkg/apis/authentication/v1beta1
+  - pkg/apis/authorization
+  - pkg/apis/authorization/v1
+  - pkg/apis/authorization/v1beta1
+  - pkg/apis/autoscaling
+  - pkg/apis/autoscaling/v1
+  - pkg/apis/autoscaling/v2alpha1
+  - pkg/apis/batch
+  - pkg/apis/batch/v1
+  - pkg/apis/batch/v2alpha1
+  - pkg/apis/certificates
+  - pkg/apis/certificates/v1beta1
+  - pkg/apis/extensions
+  - pkg/apis/extensions/v1beta1
+  - pkg/apis/networking
+  - pkg/apis/networking/v1
+  - pkg/apis/policy
+  - pkg/apis/policy/v1beta1
+  - pkg/apis/rbac
+  - pkg/apis/rbac/v1alpha1
+  - pkg/apis/rbac/v1beta1
+  - pkg/apis/settings
+  - pkg/apis/settings/v1alpha1
+  - pkg/apis/storage
+  - pkg/apis/storage/v1
+  - pkg/apis/storage/v1beta1
+  - pkg/labels
+  - pkg/util
+  - pkg/util/intstr
+  - pkg/util/parsers
+  - pkg/version
+  - plugin/pkg/client/auth
+  - plugin/pkg/client/auth/azure
+  - plugin/pkg/client/auth/gcp
+  - plugin/pkg/client/auth/oidc
+  - rest
+  - rest/watch
+  - third_party/forked/golang/template
+  - tools/auth
+  - tools/cache
+  - tools/clientcmd
+  - tools/clientcmd/api
+  - tools/clientcmd/api/latest
+  - tools/clientcmd/api/v1
+  - tools/metrics
+  - transport
+  - util/cert
+  - util/flowcontrol
+  - util/homedir
+  - util/integer
+  - util/jsonpath
 testImports:
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d

--- a/glide.lock
+++ b/glide.lock
@@ -34,10 +34,10 @@ imports:
   - log
   - swagger
 - name: github.com/fission/fission
-  version: 52c77c5bf5b6b54249ab049c9035e3c16df53f25
+  version: b2678783b63b4dccda8e6b02ca1adf292e1bb183
   subpackages:
   - controller/client
-  - poolmgr/client
+  - executor/client
   - tpr
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee

--- a/glide.yaml
+++ b/glide.yaml
@@ -37,7 +37,7 @@ import:
   version: v2.0.0
 - package: gopkg.in/yaml.v2
 - package: github.com/fission/fission
-  version: ^0.3.0-rc
+  version: b2678783b63b4dccda8e6b02ca1adf292e1bb183
   # Due to the old version of the kubernetes client we need to fix the openapi versions to avoid incompatible interfaces.
 - package: github.com/go-openapi/errors
   version: 49fe8b3a0e0d32a617d8d50c67f856ad6e45b28b

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,6 +4,10 @@ license: Apache-2.0
 excludeDirs:
 - local
 import:
+- package: github.com/fission/fission
+  version: b2678783b63b4dccda8e6b02ca1adf292e1bb183
+- package: golang.org/x/text
+  version: 88f656faf3f37f690df1a32515b479415e1a6769
 - package: github.com/sirupsen/logrus
   version: 68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a
 - package: github.com/urfave/cli
@@ -36,8 +40,6 @@ import:
 - package: gopkg.in/sourcemap.v1
   version: v2.0.0
 - package: gopkg.in/yaml.v2
-- package: github.com/fission/fission
-  version: b2678783b63b4dccda8e6b02ca1adf292e1bb183
   # Due to the old version of the kubernetes client we need to fix the openapi versions to avoid incompatible interfaces.
 - package: github.com/go-openapi/errors
   version: 49fe8b3a0e0d32a617d8d50c67f856ad6e45b28b

--- a/pkg/fnenv/fission/resolver.go
+++ b/pkg/fnenv/fission/resolver.go
@@ -3,7 +3,8 @@ package fission
 import (
 	"github.com/fission/fission/controller/client"
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/1.5/pkg/api"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Resolver struct {
@@ -16,7 +17,7 @@ func NewResolver(controller *client.Client) *Resolver {
 
 func (re *Resolver) Resolve(fnName string) (string, error) {
 	logrus.WithField("name", fnName).Info("Resolving function ")
-	fn, err := re.controller.FunctionGet(&api.ObjectMeta{
+	fn, err := re.controller.FunctionGet(&metav1.ObjectMeta{
 		Name: fnName,
 	})
 	if err != nil {

--- a/pkg/fnenv/fission/runtime.go
+++ b/pkg/fnenv/fission/runtime.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/fission/fission-workflows/pkg/types"
 	"github.com/fission/fission-workflows/pkg/types/typedvalues"
-	poolmgr "github.com/fission/fission/poolmgr/client"
+	executor "github.com/fission/fission/executor/client"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/1.5/pkg/api"
 
@@ -22,14 +22,14 @@ import (
 
 // FunctionEnv adapts the Fission platform to the function execution runtime.
 type FunctionEnv struct {
-	poolmgr *poolmgr.Client
-	ct      *ContentTypeMapper
+	executor *executor.Client
+	ct       *ContentTypeMapper
 }
 
-func NewFunctionEnv(poolmgr *poolmgr.Client) *FunctionEnv {
+func NewFunctionEnv(executor *executor.Client) *FunctionEnv {
 	return &FunctionEnv{
-		poolmgr: poolmgr,
-		ct:      &ContentTypeMapper{typedvalues.DefaultParserFormatter},
+		executor: executor,
+		ct:       &ContentTypeMapper{typedvalues.DefaultParserFormatter},
 	}
 }
 
@@ -42,7 +42,7 @@ func (fe *FunctionEnv) Invoke(spec *types.TaskInvocationSpec) (*types.TaskInvoca
 	logrus.WithFields(logrus.Fields{
 		"metadata": meta,
 	}).Info("Invoking Fission function.")
-	serviceUrl, err := fe.poolmgr.GetServiceForFunction(meta)
+	serviceUrl, err := fe.executor.GetServiceForFunction(meta)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
 			"err":  err,

--- a/pkg/fnenv/fission/runtime.go
+++ b/pkg/fnenv/fission/runtime.go
@@ -12,12 +12,12 @@ import (
 	"github.com/fission/fission-workflows/pkg/types/typedvalues"
 	executor "github.com/fission/fission/executor/client"
 	"github.com/sirupsen/logrus"
-	"k8s.io/client-go/1.5/pkg/api"
 
 	"strings"
 
 	"github.com/fission/fission/router"
-	k8stypes "k8s.io/client-go/1.5/pkg/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 )
 
 // FunctionEnv adapts the Fission platform to the function execution runtime.
@@ -34,10 +34,10 @@ func NewFunctionEnv(executor *executor.Client) *FunctionEnv {
 }
 
 func (fe *FunctionEnv) Invoke(spec *types.TaskInvocationSpec) (*types.TaskInvocationStatus, error) {
-	meta := &api.ObjectMeta{
+	meta := &metav1.ObjectMeta{
 		Name:      spec.GetType().GetSrc(),
 		UID:       k8stypes.UID(spec.GetType().GetResolved()),
-		Namespace: api.NamespaceDefault,
+		Namespace: metav1.NamespaceDefault,
 	}
 	logrus.WithFields(logrus.Fields{
 		"metadata": meta,

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-const VERSION = "0.1.2"
+const VERSION = "0.1.3"


### PR DESCRIPTION
Update the dependency on fission to include https://github.com/fission/fission/commit/b2678783b63b4dccda8e6b02ca1adf292e1bb183

This involves
- replacing references to k8s client to use apimachinery version
- renaming poolmgr references to executor
- fix golang.com/x/text to avoid a conflicting dependency