### PR TITLE
Add environment variables to deployment

### DIFF
--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -67,9 +67,9 @@ spec:
     - name: "ES_NATS_CLUSTER"
       value: "{{ .Values.nats.cluster }}"
     - name: "FNENV_FISSION_CONTROLLER"
-      value: "{{ .Values.fnenv.fission.executor }}.{{ .Values.fnenv.fission.ns }}"
-    - name: "FNENV_FISSION_EXECUTOR"
       value: "{{ .Values.fnenv.fission.controller }}.{{ .Values.fnenv.fission.ns }}"
+    - name: "FNENV_FISSION_EXECUTOR"
+      value: "{{ .Values.fnenv.fission.executor }}.{{ .Values.fnenv.fission.ns }}"
   builder:
     image: "{{ .Values.buildEnvImage }}:{{.Values.tag}}"
     command: "defaultBuild"

--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         ]
         env:
         - name: ES_NATS_URL
-          value: "nats://{{ .Values.nats.authToken }}@{{ .Values.nats.location }}:{{ .Values.nats.port }}"
+          value: "nats://{{ .Values.nats.authToken }}@{{ .Values.nats.location }}.{{ .Values.fnenv.fission.ns }}:{{ .Values.nats.port }}"
         - name: ES_NATS_CLUSTER
           value: "{{ .Values.nats.cluster }}"
         - name: FNENV_FISSION_EXECUTOR
@@ -62,13 +62,13 @@ spec:
   runtime:
     image: "{{ .Values.envImage }}:{{.Values.tag}}"
     env:
-    - name: ES_NATS_URL
-      value: "nats://{{ .Values.nats.cluster }}.{{ .Values.fnenv.fission.ns }}:{{ .Values.nats.port }}"
-    - name: ES_NATS_CLUSTER
+    - name: "ES_NATS_URL"
+      value: "nats://{{ .Values.nats.authToken }}@{{ .Values.nats.location }}.{{ .Values.fnenv.fission.ns }}:{{ .Values.nats.port }}"
+    - name: "ES_NATS_CLUSTER"
       value: "{{ .Values.nats.cluster }}"
-    - name: FNENV_FISSION_CONTROLLER
+    - name: "FNENV_FISSION_CONTROLLER"
       value: "{{ .Values.fnenv.fission.executor }}.{{ .Values.fnenv.fission.ns }}"
-    - name: FNENV_FISSION_EXECUTOR
+    - name: "FNENV_FISSION_EXECUTOR"
       value: "{{ .Values.fnenv.fission.controller }}.{{ .Values.fnenv.fission.ns }}"
   builder:
     image: "{{ .Values.buildEnvImage }}:{{.Values.tag}}"

--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -27,14 +27,13 @@ spec:
         ]
         env:
         - name: ES_NATS_URL
-#          value: nats://defaultFissionAuthToken@nats-streaming:4222
-          value: nats://{{ .Values.nats.authToken }}@{{ .Values.nats.location }}
+          value: "nats://{{ .Values.nats.authToken }}@{{ .Values.nats.location }}:{{ .Values.nats.port }}"
         - name: ES_NATS_CLUSTER
           value: "{{ .Values.nats.cluster }}"
         - name: FNENV_FISSION_EXECUTOR
-          value: "{{ .Values.fnenv.fission.executor }}"
+          value: "{{ .Values.fnenv.fission.executor }}.{{ .Values.fnenv.fission.ns }}"
         - name: FNENV_FISSION_CONTROLLER
-          value: "{{ .Values.fnenv.fission.controller }}"
+          value: "{{ .Values.fnenv.fission.controller }}.{{ .Values.fnenv.fission.ns }}"
 ---
 apiVersion: v1
 kind: Service
@@ -61,8 +60,16 @@ metadata:
 spec:
   version: 2
   runtime:
-  # TODO Add environment variables for environment once supported by Fission
     image: "{{ .Values.envImage }}:{{.Values.tag}}"
+    env:
+    - name: ES_NATS_URL
+      value: "nats://{{ .Values.nats.cluster }}.{{ .Values.fnenv.fission.ns }}:{{ .Values.nats.port }}"
+    - name: ES_NATS_CLUSTER
+      value: "{{ .Values.nats.cluster }}"
+    - name: FNENV_FISSION_CONTROLLER
+      value: "{{ .Values.fnenv.fission.executor }}.{{ .Values.fnenv.fission.ns }}"
+    - name: FNENV_FISSION_EXECUTOR
+      value: "{{ .Values.fnenv.fission.controller }}.{{ .Values.fnenv.fission.ns }}"
   builder:
     image: "{{ .Values.buildEnvImage }}:{{.Values.tag}}"
     command: "defaultBuild"

--- a/charts/fission-workflows/values.yaml
+++ b/charts/fission-workflows/values.yaml
@@ -21,11 +21,13 @@ apiserver: true
 # Fission configuration
 fnenv:
   fission:
-    controller: http://controller.fission
-    executor: http://executor.fission
+    ns: fission
+    controller: http://controller
+    executor: http://executor
 
 # Message queue config
 nats:
   authToken: defaultFissionAuthToken
   cluster: fissionMQTrigger
-  location: nats-streaming:4222
+  location: nats-streaming
+  port: 4222

--- a/compiling.md
+++ b/compiling.md
@@ -22,8 +22,8 @@ bash ./build-linux.sh
 # Optional: Ensure that you target the right docker registry (assuming minikube)
 eval $(minikube docker-env)
 
-# Build the docker image
-bash ./docker.sh
+# Build the docker images
+bash ./docker.sh fission latest
 ```
 
 To deploy your locally compiled version. **As of writing Fission Workflows, requires fission to be installed 

--- a/pkg/api/workflow/parse/resolver.go
+++ b/pkg/api/workflow/parse/resolver.go
@@ -41,7 +41,10 @@ func (ps *Resolver) Resolve(spec *types.WorkflowSpec) (*types.WorkflowStatus, er
 	taskTypes := map[string]*types.TaskTypeDef{}
 	for taskId, task := range spec.GetTasks() {
 		go func(taskId string, task *types.Task) {
-			lastErr = ps.resolveTaskAndInputs(task, taskTypes)
+			err := ps.resolveTaskAndInputs(task, taskTypes)
+			if err != nil {
+				lastErr = err
+			}
 			wg.Done()
 		}(taskId, task)
 	}

--- a/pkg/controller/invocation.go
+++ b/pkg/controller/invocation.go
@@ -120,7 +120,7 @@ func (cr *InvocationController) Init() error {
 					err := action.Apply()
 					state := cr.states[action.Id()]
 					if err != nil {
-						logrus.WithField("action", action).Error("WorkflowInvocation action failed")
+						logrus.WithField("action", action).Errorf("WorkflowInvocation action failed: %v", err)
 						state.recentError = err
 						state.errorCount += 1
 					} else {
@@ -238,6 +238,7 @@ func (cr *InvocationController) evaluate(invoc *types.WorkflowInvocation) {
 
 	// Check if workflow is in the right state to use.
 	if wf.Status.Status != types.WorkflowStatus_READY {
+		// TODO backoff
 		logrus.WithField("wf.status", wf.Status.Status).Error("Workflow has not been parsed yet.")
 		return
 	}
@@ -371,7 +372,7 @@ func (a *invokeTaskAction) Apply() error {
 	// Resolve type of the task
 	taskDef, ok := a.wf.Status.ResolvedTasks[task.FunctionRef]
 	if !ok {
-		return fmt.Errorf("no resolved task could be found for FunctionRef'%v'", task.FunctionRef)
+		return fmt.Errorf("no resolved task could be found for FunctionRef '%v'", task.FunctionRef)
 	}
 
 	// Resolve the inputs

--- a/pkg/controller/workflow.go
+++ b/pkg/controller/workflow.go
@@ -125,10 +125,10 @@ func (ctr *WorkflowController) HandleNotification(msg *fes.Notification) {
 	}
 
 	// Check if the target workflow is not in a backoff
-	locked := ctr.wfBackoff.Locked(wf.Aggregate().Id, time.Now())
-	if locked {
-		return
-	}
+	//locked := ctr.wfBackoff.Locked(wf.Aggregate().Id, time.Now())
+	//if locked {
+	//	return
+	//}
 
 	err := ctr.evaluate(wf.Workflow)
 	if err != nil {
@@ -174,7 +174,7 @@ func (ctr *WorkflowController) HandleAction(action Action) {
 		actionLog.Errorf("Failed to perform action: %v", err)
 		bkf := ctr.wfBackoff.Backoff(action.Id())
 		actionLog.Infof("Set evaluation backoff to %d ms (attempt: %v)",
-			bkf.Lockout.Nanoseconds() / 1000, bkf.Attempts)
+			bkf.Lockout.Nanoseconds()/1000, bkf.Attempts)
 	}
 }
 

--- a/pkg/controller/workflow.go
+++ b/pkg/controller/workflow.go
@@ -76,10 +76,7 @@ func (ctr *WorkflowController) Init() error {
 		for {
 			select {
 			case action := <-ctr.workQueue:
-				err := action.Apply()
-				if err != nil {
-					logrus.WithField("action", action).Error("Workflow action failed")
-				}
+				ctr.HandleAction(action)
 			case <-ctx.Done():
 				logrus.WithField("ctx.err", ctx.Err()).Debug("Action workQueue worker closed.")
 				return
@@ -170,10 +167,14 @@ func (ctr *WorkflowController) submit(action Action) (submitted bool) {
 }
 
 func (ctr *WorkflowController) HandleAction(action Action) {
+	actionLog := logrus.WithField("action", action.Id())
+	actionLog.Info("Handling action.")
 	err := action.Apply()
 	if err != nil {
-		logrus.Errorf("Failed to perform action: %v", err)
-		ctr.wfBackoff.Backoff(action.Id())
+		actionLog.Errorf("Failed to perform action: %v", err)
+		bkf := ctr.wfBackoff.Backoff(action.Id())
+		actionLog.Infof("Set evaluation backoff to %d ms (attempt: %v)",
+			bkf.Lockout.Nanoseconds() / 1000, bkf.Attempts)
 	}
 }
 

--- a/pkg/fnenv/fission/resolver.go
+++ b/pkg/fnenv/fission/resolver.go
@@ -18,7 +18,7 @@ func NewResolver(controller *client.Client) *Resolver {
 func (re *Resolver) Resolve(fnName string) (string, error) {
 	logrus.WithField("name", fnName).Info("Resolving function ")
 	fn, err := re.controller.FunctionGet(&metav1.ObjectMeta{
-		Name: fnName,
+		Name:      fnName,
 		Namespace: metav1.NamespaceDefault,
 	})
 	if err != nil {

--- a/pkg/fnenv/fission/resolver.go
+++ b/pkg/fnenv/fission/resolver.go
@@ -19,6 +19,7 @@ func (re *Resolver) Resolve(fnName string) (string, error) {
 	logrus.WithField("name", fnName).Info("Resolving function ")
 	fn, err := re.controller.FunctionGet(&metav1.ObjectMeta{
 		Name: fnName,
+		Namespace: metav1.NamespaceDefault,
 	})
 	if err != nil {
 		return "", err

--- a/pkg/util/backoff/backoff_test.go
+++ b/pkg/util/backoff/backoff_test.go
@@ -1,0 +1,20 @@
+package backoff
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBackoff_DefaultBackoffAlgorithm(t *testing.T) {
+	b := Backoff()
+
+	assert.Equal(t, DefaultBackoffAlgorithm, b.Algorithm)
+	assert.Equal(t, 1, b.Attempts)
+
+	b2 := Backoff(b)
+
+	assert.Equal(t, DefaultBackoffAlgorithm, b2.Algorithm)
+	assert.Equal(t, 2, b2.Attempts)
+	assert.True(t, b2.LockedUntil.After(b.LockedUntil))
+	assert.True(t, b2.Lockout.Nanoseconds() > b.Lockout.Nanoseconds())
+}

--- a/pkg/util/backoff/backoff_test.go
+++ b/pkg/util/backoff/backoff_test.go
@@ -1,8 +1,8 @@
 package backoff
 
 import (
-	"testing"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestBackoff_DefaultBackoffAlgorithm(t *testing.T) {


### PR DESCRIPTION
This PR adds environment variables to the Fission Workflow environment in the (Helm) deployment.

Flybys:
- Fixes a bug in the backoff utility
- improves logging and error handling in a couple of places