### PR TITLE
Add support for inputs specifying task metadata

### DIFF
--- a/examples/whales/README.md
+++ b/examples/whales/README.md
@@ -1,29 +1,56 @@
 # Simple Examples
-This directory contains two simple example workflows (and two whales!), along with the required functions.
+This directory contains multiple simple example workflows (and whales!), along with the required functions.
+The intention of each workflow is to show-off and explain a concept in Fission Workflows
 
 ## Setup
 - Make sure that you have a running Fission Cluster with the workflow engine, see the [readme](../../README.md) for details.
 - Deploy both the functions, using the [deploy.sh](./deploy.sh) script, or run the commands listed there manually.
 
-### Example: Echowhale
-The 'echowhale' workflow is a minimal workflow, consisting of whale echoing the input.
+## Examples
+
+
+### Echowhale
+The `echowhale` workflow is a minimal workflow, consisting of whale echoing the input.
 The main feature it shows is that a workflow from the user's view the same as a Fission function.
 
-To invoke:
+Run:
 ```bash
-curl -XPOST -d 'Whale you echo?' $FISSION_ROUTER/fission-function/echowhale
+curl -XPOST -d 'Whale you echo?' ${FISSION_ROUTER}/fission-function/echowhale
 ```
 
-### Example: Fortunewhale
-The fortunewhale workflow consists of multiple steps, generating a 'fortune' and passing it through the whalesay function that was used in the first workflow.
+### Fortunewhale
+The `fortunewhale` workflow consists of multiple steps, generating a 'fortune' and passing it through the whalesay function that was used in the first workflow.
 The features introduced in this example:
 - Dependencies between tasks
 - Mapping a task's output to another task's input
 - The 'noop' internal function, which is a function executed within the engine itself.
 
-To invoke:
+Run:
 ```bash
-curl -XPOST $FISSION_ROUTER/fission-function/fortunewhale
+curl -XPOST ${FISSION_ROUTER}/fission-function/fortunewhale
 ```
 
-### Example: 
+### Maybewhale
+The `maybewhale` workflow consists of a simple if-else condition.
+Depending on the length of the input, the workflow transforms the input.
+If the input is smaller than 20 characters, the workflow will run the `whalesay` task.
+If not, it will simply propagate the user input.
+
+Run:
+```bash
+# This will wrap the input in a whale, because the input is < 20
+curl -XPOST -d 'Whale you echo?' ${FISSION_ROUTER}/fission-function/maybewhale
+
+# This will simply echo the input, because the input is >= 20.
+curl -XPOST -d 'Whale you echo this way too long message?' ${FISSION_ROUTER}/fission-function/maybewhale
+```
+
+### Nestedwhale
+The `nestedwhale` workflow is surprisingly... empty.
+The principle that 'workflows are fission functions', allows workflows to call other workflows just like you would call regular Fission Functions.
+In this workflow, we generate a fortune and pass it to the dedicated whale echoing workflow: `echowhale`.
+
+Run
+```bash
+curl -XPOST ${FISSION_ROUTER}/fission-function/nestedwhale
+```

--- a/examples/whales/README.md
+++ b/examples/whales/README.md
@@ -45,6 +45,14 @@ curl -XPOST -d 'Whale you echo?' ${FISSION_ROUTER}/fission-function/maybewhale
 curl -XPOST -d 'Whale you echo this way too long message?' ${FISSION_ROUTER}/fission-function/maybewhale
 ```
 
+### Metadatawhale
+The `metadatawhale` workflow shows how to add metadata (headers, query values) to tasks.
+
+Run:
+```bash
+curl -XPOST ${FISSION_ROUTER}/fission-function/metadatawhale
+```
+
 ### Nestedwhale
 The `nestedwhale` workflow is surprisingly... empty.
 The principle that 'workflows are fission functions', allows workflows to call other workflows just like you would call regular Fission Functions.

--- a/examples/whales/deploy.sh
+++ b/examples/whales/deploy.sh
@@ -14,3 +14,4 @@ fission fn create --name fortunewhale --env workflow --src ./fortunewhale.wf.yam
 fission fn create --name echowhale --env workflow --src ./echowhale.wf.yaml
 fission fn create --name maybewhale --env workflow --src ./maybewhale.wf.yaml
 fission fn create --name nestedwhale --env workflow --src ./nestedwhale.wf.yaml
+fission fn create --name metadatawhale --env workflow --src ./metadatawhale.wf.yaml

--- a/examples/whales/deploy.sh
+++ b/examples/whales/deploy.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
+# deploy.sh - deploys all functions and workflows in this directory
+
 set -x
 
 # Deploy functions
-fission env create --name binary --image fission/binary-env:0.3.0
+fission env create --name binary --image fission/binary-env
 fission fn create --name whalesay --env binary --deploy ./whalesay.sh
 fission fn create --name fortune --env binary --deploy ./fortune.sh
 

--- a/examples/whales/echowhale.wf.yaml
+++ b/examples/whales/echowhale.wf.yaml
@@ -1,3 +1,4 @@
+# This whale shows how to access and reference with workflow parameters
 apiVersion: 1
 output: echowhale
 tasks:

--- a/examples/whales/fortune.sh
+++ b/examples/whales/fortune.sh
@@ -9,4 +9,11 @@ if ! hash fortune 2>/dev/null; then
     apk add fortune > /dev/null
 fi
 
+# Pretty useless, but used to show headers
+prefix=${HTTP_PREFIX}
+
+if [ ! -z "${prefix}" ] ; then
+    printf "${prefix}"
+fi
+
 fortune -s

--- a/examples/whales/fortune.sh
+++ b/examples/whales/fortune.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# fortune - generate wise words
+#
+# Output: string (plain text)
+
+# TODO move this to the build step once the binary environment is a v2 environment
 if ! hash fortune 2>/dev/null; then
     apk add fortune > /dev/null
 fi

--- a/examples/whales/fortunewhale.wf.yaml
+++ b/examples/whales/fortunewhale.wf.yaml
@@ -1,3 +1,4 @@
+# This whale shows of a basic workflow that combines both Fission Functions (fortune, whalesay) and internal functions (noop)
 apiVersion: 1
 output: WhaleWithFortune
 tasks:

--- a/examples/whales/maybewhale.wf.yaml
+++ b/examples/whales/maybewhale.wf.yaml
@@ -1,3 +1,4 @@
+# A whale that shows off how a if-condition works in a workflow
 apiVersion: 1
 output: PassAlong
 tasks:

--- a/examples/whales/metadatawhale.wf.yaml
+++ b/examples/whales/metadatawhale.wf.yaml
@@ -1,0 +1,5 @@
+# A whale that shows off how to add metadata (e.g. headers, query) to your fission function
+apiVersion: 1
+output: PassAlong
+tasks:
+

--- a/examples/whales/metadatawhale.wf.yaml
+++ b/examples/whales/metadatawhale.wf.yaml
@@ -1,5 +1,8 @@
 # A whale that shows off how to add metadata (e.g. headers, query) to your fission function
 apiVersion: 1
-output: PassAlong
+output: PrefixedFortune
 tasks:
-
+  PrefixedFortune:
+    run: fortune
+    inputs:
+      header_prefix: "Whale says:"

--- a/examples/whales/nestedwhale.wf.yaml
+++ b/examples/whales/nestedwhale.wf.yaml
@@ -1,3 +1,4 @@
+# This whale shows of how to call other workflows from a workflow (surprise! There is no difference with regular functions)
 apiVersion: 1
 output: WhaleIt
 tasks:

--- a/examples/whales/whalesay.sh
+++ b/examples/whales/whalesay.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# whalesay - let a friendly whale say your message instead
+#
+# input: string (plain text)
+# output: string (plain text)
+
+# TODO move this to the build step once the binary environment is a v2 environment
 if ! hash cowsay 2> /dev/null; then
     apk update > /dev/null
     apk add curl perl > /dev/null

--- a/pkg/fnenv/fission/envproxy.go
+++ b/pkg/fnenv/fission/envproxy.go
@@ -123,7 +123,7 @@ func (fp *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	var resp []byte
 	if invocation.Status.Output != nil {
 		resp = invocation.Status.Output.Value
-		w.Header().Add("Content-Type", ToContentType(invocation.Status.Output))
+		w.Header().Add("Content-Type", inferContentType(invocation.Status.Output, defaultContentType))
 	} else {
 		logrus.Infof("Invocation '%v' has no output.", fnId)
 	}

--- a/pkg/fnenv/fission/runtime.go
+++ b/pkg/fnenv/fission/runtime.go
@@ -52,8 +52,8 @@ func (fe *FunctionEnv) Invoke(spec *types.TaskInvocationSpec) (*types.TaskInvoca
 	}
 	logrus.WithFields(logrus.Fields{
 		"name": meta.Name,
-		"UID": meta.UID,
-		"ns": meta.Namespace,
+		"UID":  meta.UID,
+		"ns":   meta.Namespace,
 	}).Info("Invoking Fission function.")
 
 	// Get reqUrl

--- a/pkg/fnenv/fission/runtime.go
+++ b/pkg/fnenv/fission/runtime.go
@@ -18,18 +18,29 @@ import (
 	"github.com/fission/fission/router"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"net/url"
 )
 
 // FunctionEnv adapts the Fission platform to the function execution runtime.
 type FunctionEnv struct {
 	executor *executor.Client
-	ct       *ContentTypeMapper
 }
+
+const (
+	InputBody          = "body" // or 'default'
+	InputHttpMethod    = "http_method"
+	InputHeaderPrefix  = "header_"
+	InputQueryPrefix   = "query_"
+	InputContentType   = "content_type" // to force the content type
+
+	defaultHttpMethod  = http.MethodPost
+	defaultProtocol    = "http"
+	defaultContentType = "text/plain"
+)
 
 func NewFunctionEnv(executor *executor.Client) *FunctionEnv {
 	return &FunctionEnv{
 		executor: executor,
-		ct:       &ContentTypeMapper{typedvalues.DefaultParserFormatter},
 	}
 }
 
@@ -42,53 +53,79 @@ func (fe *FunctionEnv) Invoke(spec *types.TaskInvocationSpec) (*types.TaskInvoca
 	logrus.WithFields(logrus.Fields{
 		"metadata": meta,
 	}).Info("Invoking Fission function.")
+
+	// Get reqUrl
 	serviceUrl, err := fe.executor.GetServiceForFunction(meta)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
 			"err":  err,
 			"meta": meta,
-		}).Error("Fission function failed!")
+		}).Error("Fission function could not be found!")
 		return nil, err
 	}
-
-	url := fmt.Sprintf("http://%s", serviceUrl)
+	rawUrl := fmt.Sprintf("%s://%s", defaultProtocol, serviceUrl)
+	reqUrl, err := url.Parse(rawUrl)
+	if err != nil {
+		logrus.Errorf("Failed to parse url: '%v'", rawUrl)
+		panic(err)
+	}
 
 	// Map input parameters to actual Fission function parameters
 
+	// Map body parameter
 	var input []byte
-	mainInput, ok := spec.Inputs[types.INPUT_MAIN]
-	if ok {
+	mainInput, _ := getFirstDefinedTypedValue(spec.Inputs, types.INPUT_MAIN, InputBody)
+	if mainInput != nil {
 		input = mainInput.Value
-	} else {
-		mainInput, ok := spec.Inputs["body"]
-		if ok {
-			input = mainInput.Value
-		}
 	}
 
 	r := bytes.NewReader(input)
 	logrus.Infof("[request][body]: %v", string(input))
-	// TODO map other parameters as well (to params)
 
-	req, err := http.NewRequest(http.MethodPost, url, r)
+	// Map HTTP method
+	httpMethod := httpMethod(spec.Inputs, defaultHttpMethod)
+	logrus.Infof("Using HTTP method: %v", httpMethod)
+
+	// Map headers
+	headers := headers(spec.Inputs)
+
+	// Determine ContentType
+	reqContentType := contentType(spec.Inputs, mainInput, defaultContentType)
+
+	// Map query and add to url
+	query := query(spec.Inputs)
+	reqUrl.RawQuery = query.Encode()
+
+	// Construct request and add body
+	req, err := http.NewRequest(httpMethod, reqUrl.String(), nil)
 	if err != nil {
 		panic(fmt.Errorf("failed to make request for '%s': %v", serviceUrl, err))
 	}
 	defer req.Body.Close()
 
+	// Add body
+	req.Body = ioutil.NopCloser(r)
+
+	// Add parameters normally added by Fission
 	router.MetadataToHeaders(router.HEADERS_FISSION_FUNCTION_PREFIX, meta, req)
 
-	reqContentType := ToContentType(mainInput)
-	logrus.Infof("[request][Content-Type]: %v", reqContentType)
+	// Set headers
+	for k, v := range headers {
+		req.Header.Set(k, v)
+		// TODO check that no special headers are overwritten
+	}
 	req.Header.Set("Content-Type", reqContentType)
 
+	// Perform request
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error for url '%s': %v", serviceUrl, err)
+		return nil, fmt.Errorf("error for reqUrl '%s': %v", serviceUrl, err)
 	}
 
+	// Parse output
+	output := toTypedValue(resp)
+
 	logrus.Infof("[%s][Content-Type]: %v ", meta.Name, resp.Header.Get("Content-Type"))
-	output := ToTypedValue(resp)
 	logrus.Infof("[%s][output]: %v", meta.Name, output)
 	logrus.Infof("[%s][status]: %v", meta.Name, resp.StatusCode)
 
@@ -111,28 +148,7 @@ func (fe *FunctionEnv) Invoke(spec *types.TaskInvocationSpec) (*types.TaskInvoca
 	}, nil
 }
 
-type ContentTypeMapper struct {
-	parserFormatter typedvalues.ParserFormatter
-}
-
-var formatMapping = map[string]string{
-	typedvalues.FORMAT_JSON: "application/json",
-}
-
-func ToContentType(val *types.TypedValue) string {
-	contentType := "text/plain"
-	if val == nil {
-		return contentType
-	}
-
-	// Temporary solution
-	if strings.HasPrefix(val.Type, "json") {
-		contentType = "application/json"
-	}
-	return contentType
-}
-
-func ToTypedValue(resp *http.Response) *types.TypedValue {
+func toTypedValue(resp *http.Response) *types.TypedValue {
 	contentType := strings.ToLower(resp.Header.Get("Content-Type"))
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
@@ -154,4 +170,79 @@ func ToTypedValue(resp *http.Response) *types.TypedValue {
 		panic(err)
 	}
 	return tv
+}
+
+func getFirstDefinedTypedValue(inputs map[string]*types.TypedValue, fields ...string) (*types.TypedValue, string) {
+	var result *types.TypedValue
+	var f string
+	for _, f = range fields {
+		val, ok := inputs[f]
+		if ok {
+			result = val
+			break
+		}
+	}
+	return result, f
+}
+
+func toString(tv *types.TypedValue) string {
+	if tv == nil {
+		return ""
+	}
+	i, err := typedvalues.Format(tv)
+	if err != nil {
+		logrus.Warn("Failed to format input: %v", err)
+	}
+
+	return fmt.Sprintf("%v", i)
+}
+
+func httpMethod(inputs map[string]*types.TypedValue, defaultHttpMethod string) string {
+	tv, _ := getFirstDefinedTypedValue(inputs, InputHttpMethod)
+
+	httpMethod := toString(tv)
+	if httpMethod == "" {
+		return defaultHttpMethod
+	}
+	return httpMethod
+}
+
+func contentType(inputs map[string]*types.TypedValue, mainInput *types.TypedValue, defaultContentType string) string {
+	// Check if content type is forced
+	tv, _ := getFirstDefinedTypedValue(inputs, InputContentType, InputHeaderPrefix+InputContentType)
+	contentType := toString(tv)
+	if contentType != "" {
+		return contentType
+	}
+	return inferContentType(mainInput, defaultContentType)
+}
+
+func inferContentType(mainInput *types.TypedValue, defaultContentType string) string {
+	// Infer content type from main input  (TODO Temporary solution)
+	if strings.HasPrefix(mainInput.Type, "json") {
+		return "application/json"
+	}
+
+	// Use default content type
+	return defaultContentType
+}
+
+func headers(inputs map[string]*types.TypedValue) map[string]string { // TODO support multi-headers at some point
+	result := map[string]string{}
+	for k, v := range inputs {
+		if strings.HasPrefix(k, InputHeaderPrefix) {
+			result[k] = toString(v)
+		}
+	}
+	return result
+}
+
+func query(inputs map[string]*types.TypedValue) url.Values { // TODO support multi-headers at some point
+	result := url.Values{}
+	for k, v := range inputs {
+		if strings.HasPrefix(k, InputQueryPrefix) {
+			result.Add(k, toString(v))
+		}
+	}
+	return result
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,10 +1,17 @@
 package types
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Types other than specified in protobuf
 const (
 	SUBJECT_INVOCATION = "invocation"
 	SUBJECT_WORKFLOW   = "workflows"
 	INPUT_MAIN         = "default"
+
+	typedValueShortMaxLen = 32
 )
 
 // InvocationEvent
@@ -41,4 +48,16 @@ func (ti TaskInvocationStatus_Status) Finished() bool {
 		}
 	}
 	return false
+}
+
+// Prints a short description of the value
+func (tv TypedValue) Short() string {
+	var val string
+	if len(tv.Value) > typedValueShortMaxLen {
+		val = fmt.Sprintf("%s[..%d..]", tv.Value[:typedValueShortMaxLen], len(tv.Value)-typedValueShortMaxLen)
+	} else {
+		val = fmt.Sprintf("%s", tv.Value)
+	}
+
+	return fmt.Sprintf("<Type=\"%s\", Val=\"%v\">", tv.Type, strings.Replace(val, "\n", "", -1))
 }


### PR DESCRIPTION
This PR adds support for users to specify headers (and queries)
The main advantage of using headers is that those explicitly do not get recorded anywhere. They are specific to a task and do not get propagated through 

It currently uses a quick experimental format detecting inputs with a key `header_*` as headers and `query_*` as query params. In the future it might be an option to change it to an object-based format:
```
headers:
  key: val
```
Or support both ways of defining headers.

As flybys:
- User can force the Content type of the request
- Updated / improved the documentation of the examples
- Added a util function to limit the printing of a TypedValue to avoid cluttering of the UI.