### PR TITLE
Breakup CLI into multiple files

### DIFF
--- a/build/env/Dockerfile
+++ b/build/env/Dockerfile
@@ -10,4 +10,12 @@ ENV ES_NATS_URL nats://defaultFissionAuthToken@nats-streaming.fission:4222
 ENV ES_NATS_CLUSTER fissionMQTrigger
 
 # Remove APIs when components stabilize
-ENTRYPOINT ["/fission-workflows-bundle", "--nats", "--fission", "--internal", "--controller", "--api-http", "--api-workflow-invocation", "--api-workflow", "--api-admin"]
+ENTRYPOINT ["/fission-workflows-bundle", \
+            "--nats", \
+            "--fission", \
+            "--internal", \
+            "--controller", \
+            "--api-http", \
+            "--api-workflow-invocation", \
+            "--api-workflow", \
+            "--api-admin"]

--- a/cmd/wfcli/README.md
+++ b/cmd/wfcli/README.md
@@ -16,7 +16,7 @@ wfcli status # View whether the Fission Workflows deployment can be reached.
 
 wfcli workflow get # List all workflows in the workflow engine.
 
-wfcli workflow get <id> # Get the definition of a specifc workflow
+wfcli workflow get <id> # Get the definition of a specific workflow
 
 wfcli invocation get # List all invocations so-far (both in-progress and finished)
 

--- a/cmd/wfcli/config.go
+++ b/cmd/wfcli/config.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+var cmdConfig = cli.Command{
+	Name:  "config",
+	Usage: "Print wfcli config",
+	Action: func(c *cli.Context) error {
+		fmt.Println("cli:")
+		for _, flag := range c.GlobalFlagNames() {
+			fmt.Printf("  %s: %v\n", flag, c.GlobalGeneric(flag))
+		}
+		for _, flag := range c.FlagNames() {
+			fmt.Printf("  %s: %v\n", flag, c.Generic(flag))
+		}
+		return nil
+	},
+}

--- a/cmd/wfcli/invocation.go
+++ b/cmd/wfcli/invocation.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/fission/fission-workflows/cmd/wfcli/swagger-client/client/workflow_api"
+	"github.com/fission/fission-workflows/cmd/wfcli/swagger-client/client/workflow_invocation_api"
+	"github.com/fission/fission-workflows/cmd/wfcli/swagger-client/models"
+	"github.com/fission/fission-workflows/pkg/api/workflow/parse/yaml"
+	"github.com/fission/fission-workflows/pkg/types"
+	"github.com/go-openapi/strfmt"
+	"github.com/urfave/cli"
+)
+
+var cmdInvocation = cli.Command{
+	Name:    "invocation",
+	Aliases: []string{"wi", "invocations", "workflow-invocation", "wfi"},
+	Usage:   "Workflow Invocation-related commands",
+	Subcommands: []cli.Command{
+		{
+			Name:  "get",
+			Usage: "get <workflow-invocation-id> <task-invocation-id>",
+			Action: func(c *cli.Context) error {
+				u := parseUrl(c.GlobalString("url"))
+				client := createTransportClient(u)
+				wfiApi := workflow_invocation_api.New(client, strfmt.Default)
+				switch c.NArg() {
+				case 0:
+					// List workflows invocations
+					resp, err := wfiApi.List(workflow_invocation_api.NewListParams())
+					if err != nil {
+						panic(err)
+					}
+					wis := resp.Payload
+					sort.Strings(wis.Invocations)
+					var rows [][]string
+					for _, wfiId := range wis.Invocations {
+						resp, err := wfiApi.Get(workflow_invocation_api.NewGetParams().WithID(wfiId))
+						if err != nil {
+							panic(err)
+						}
+						wi := resp.Payload
+						updated := wi.Status.UpdatedAt.String()
+						created := wi.Metadata.CreatedAt.String()
+
+						rows = append(rows, []string{wfiId, wi.Spec.WorkflowID, string(wi.Status.Status),
+							created, updated})
+					}
+					table(os.Stdout, []string{"ID", "WORKFLOW", "STATUS", "CREATED", "UPDATED"}, rows)
+				case 1:
+					// Get Workflow invocation
+					wfiId := c.Args().Get(0)
+					resp, err := wfiApi.Get(workflow_invocation_api.NewGetParams().WithID(wfiId))
+					if err != nil {
+						panic(err)
+					}
+					wfi := resp.Payload
+					b, err := yaml.Marshal(wfi)
+					if err != nil {
+						panic(err)
+					}
+					fmt.Printf("%v\n", string(b))
+				case 2:
+					fallthrough
+				default:
+					wfiId := c.Args().Get(0)
+					taskId := c.Args().Get(1)
+					resp, err := wfiApi.Get(workflow_invocation_api.NewGetParams().WithID(wfiId))
+					if err != nil {
+						panic(err)
+					}
+					wfi := resp.Payload
+					ti, ok := wfi.Status.Tasks[taskId]
+					if !ok {
+						fmt.Println("Task invocation not found.")
+						return nil
+					}
+					b, err := yaml.Marshal(ti)
+					if err != nil {
+						panic(err)
+					}
+					fmt.Printf("%v\n", string(b))
+				}
+
+				return nil
+			},
+		},
+		{
+			Name:  "status",
+			Usage: "status <workflow-invocation-id> ",
+			Action: func(c *cli.Context) error {
+				if c.NArg() < 1 {
+					fmt.Println("Need workflow invocation id")
+					return nil
+				}
+				wfiId := c.Args().Get(0)
+				u := parseUrl(c.GlobalString("url"))
+				client := createTransportClient(u)
+				wfApi := workflow_api.New(client, strfmt.Default)
+				wfiApi := workflow_invocation_api.New(client, strfmt.Default)
+
+				wfiResp, err := wfiApi.Get(workflow_invocation_api.NewGetParams().WithID(wfiId))
+				if err != nil {
+					panic(err)
+				}
+				wfi := wfiResp.Payload
+
+				wfResp, err := wfApi.Get0(workflow_api.NewGet0Params().WithID(wfi.Spec.WorkflowID))
+				if err != nil {
+					panic(err)
+				}
+				wf := wfResp.Payload
+
+				wfiUpdated := wfi.Status.UpdatedAt.String()
+				wfiCreated := wfi.Metadata.CreatedAt.String()
+				table(os.Stdout, nil, [][]string{
+					{"ID", wfi.Metadata.ID},
+					{"WORKFLOW_ID", wfi.Spec.WorkflowID},
+					{"CREATED", wfiCreated},
+					{"UPDATED", wfiUpdated},
+					{"STATUS", string(wfi.Status.Status)},
+				})
+				fmt.Println()
+
+				var rows [][]string
+				rows = collectStatus(wf.Spec.Tasks, wfi.Status.Tasks, rows)
+				rows = collectStatus(wfi.Status.DynamicTasks, wfi.Status.Tasks, rows)
+
+				table(os.Stdout, []string{"TASK", "STATUS", "STARTED", "UPDATED"}, rows)
+				return nil
+			},
+		},
+	},
+}
+
+func collectStatus(tasks map[string]models.Task, taskStatus map[string]models.TaskInvocation, rows [][]string) [][]string {
+	var ids []string
+	for id := range tasks {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		status := types.TaskInvocationStatus_SCHEDULED.String()
+		updated := ""
+		started := ""
+
+		taskStatus, ok := taskStatus[id]
+		if ok {
+			status = string(taskStatus.Status.Status)
+			started = taskStatus.Metadata.CreatedAt.String()
+			updated = taskStatus.Metadata.CreatedAt.String()
+		}
+
+		rows = append(rows, []string{id, status, started, updated})
+	}
+	return rows
+}

--- a/cmd/wfcli/main.go
+++ b/cmd/wfcli/main.go
@@ -2,26 +2,15 @@ package main
 
 import (
 	"fmt"
-	"os"
-
 	"io"
+	"net/url"
+	"os"
 	"strings"
 	"text/tabwriter"
 
-	"net/url"
-
-	"github.com/fission/fission-workflows/cmd/wfcli/swagger-client/client/admin_api"
-	"github.com/fission/fission-workflows/cmd/wfcli/swagger-client/client/workflow_api"
-	"github.com/fission/fission-workflows/cmd/wfcli/swagger-client/client/workflow_invocation_api"
-	"github.com/fission/fission-workflows/cmd/wfcli/swagger-client/models"
-	"github.com/fission/fission-workflows/pkg/api/workflow/parse/yaml"
-	"github.com/fission/fission-workflows/pkg/types"
 	"github.com/fission/fission-workflows/pkg/version"
 	httptransport "github.com/go-openapi/runtime/client"
-	"github.com/go-openapi/strfmt"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/urfave/cli"
-	"sort"
 )
 
 // This is a prototype of the CLI (and will be integrated into the Fission CLI eventually).
@@ -36,7 +25,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "url, u",
-			Value:  "192.168.99.100:31319",
+			Value:  "http://localhost:31313",
 			EnvVar: "FISSION_URL",
 			Usage:  "Url to the Fission apiserver",
 		},
@@ -46,312 +35,14 @@ func main() {
 		},
 	}
 	app.Commands = []cli.Command{
-		{
-			Name:    "status",
-			Aliases: []string{"s"},
-			Usage:   "Check cluster status",
-			Action: func(c *cli.Context) error {
-				u := parseUrl(c.GlobalString("url"))
-				client := createTransportClient(u)
-				adminApi := admin_api.New(client, strfmt.Default)
-
-				resp, err := adminApi.Status(admin_api.NewStatusParams())
-				if err != nil {
-					panic(err)
-				}
-				fmt.Printf(resp.Payload.Status)
-
-				return nil
-			},
-		},
-		{
-			Name:    "config",
-			Usage:   "Print wfcli config",
-			Action: func(c *cli.Context) error {
-				fmt.Println("cli:")
-				for _, flag := range c.GlobalFlagNames() {
-					fmt.Printf("  %s: %v\n", flag, c.GlobalGeneric(flag))
-				}
-				for _, flag := range c.FlagNames() {
-					fmt.Printf("  %s: %v\n", flag, c.Generic(flag))
-				}
-				return nil
-			},
-		},
-		{
-			Name:        "parse",
-			Aliases:     []string{"p"},
-			Usage:       "parse <path-to-yaml> ",
-			Description: "Parse YAML definitions to the executable JSON format (deprecated)",
-			Action: func(c *cli.Context) error {
-
-				if c.NArg() == 0 {
-					panic("Need a path to a yaml workflow definition")
-				}
-
-				for _, path := range c.Args() {
-
-					fnName := strings.TrimSpace(path)
-
-					f, err := os.Open(fnName)
-					if err != nil {
-						panic(err)
-					}
-
-					wfDef, err := yaml.Parse(f)
-					if err != nil {
-						panic(err)
-					}
-
-					wfSpec, err := yaml.Transform(wfDef)
-					if err != nil {
-						panic(err)
-					}
-
-					marshal := jsonpb.Marshaler{
-						Indent: "  ",
-					}
-					jsonWf, err := marshal.MarshalToString(wfSpec)
-					if err != nil {
-						panic(err)
-					}
-
-					//outputFile := strings.Replace(fnName, "yaml", "json", -1)
-					//
-					//err = ioutil.WriteFile(outputFile, []byte(jsonWf), 0644)
-					//if err != nil {
-					//	panic(err)
-					//}
-					//
-					//println(outputFile)
-
-					fmt.Println(jsonWf)
-				}
-				return nil
-			},
-		},
-		{
-			Name:    "workflow",
-			Aliases: []string{"wf", "workflows"},
-			Usage:   "Workflow-related commands",
-			Subcommands: []cli.Command{
-				{
-					Name:  "get",
-					Usage: "get <workflow-id> <task-id>",
-					Action: func(c *cli.Context) error {
-						u := parseUrl(c.GlobalString("url"))
-						client := createTransportClient(u)
-						wfApi := workflow_api.New(client, strfmt.Default)
-						switch c.NArg() {
-						case 0:
-							// List workflows
-							resp, err := wfApi.List0(workflow_api.NewList0Params())
-							if err != nil {
-								panic(err)
-							}
-							wfs := resp.Payload.Workflows
-							sort.Strings(wfs)
-							rows := [][]string{}
-							for _, wfId := range wfs {
-								resp, err := wfApi.Get0(workflow_api.NewGet0Params().WithID(wfId))
-								if err != nil {
-									panic(err)
-								}
-								wf := resp.Payload
-								updated := wf.Status.UpdatedAt.String()
-								created := wf.Metadata.CreatedAt.String()
-
-								rows = append(rows, []string{wfId, wf.Spec.Name, string(wf.Status.Status),
-									created, updated})
-							}
-							table(os.Stdout, []string{"ID", "NAME", "STATUS", "CREATED", "UPDATED"}, rows)
-						case 1:
-							// Get Workflow
-							wfId := c.Args().Get(0)
-							println(wfId)
-							resp, err := wfApi.Get0(workflow_api.NewGet0Params().WithID(wfId))
-							if err != nil {
-								panic(err)
-							}
-							b, err := yaml.Marshal(resp.Payload)
-							if err != nil {
-								panic(err)
-							}
-							fmt.Printf("%v\n", string(b))
-						case 2:
-							// Get Workflow task
-							fallthrough
-						default:
-							wfId := c.Args().Get(0)
-							taskId := c.Args().Get(1)
-							resp, err := wfApi.Get0(workflow_api.NewGet0Params().WithID(wfId))
-							if err != nil {
-								panic(err)
-							}
-							wf := resp.Payload
-							task, ok := wf.Spec.Tasks[taskId]
-							if !ok {
-								fmt.Println("Task not found.")
-								return nil
-							}
-							b, err := yaml.Marshal(task)
-							if err != nil {
-								panic(err)
-							}
-							fmt.Printf("%v\n", string(b))
-						}
-
-						return nil
-					},
-				},
-			},
-		},
-		{
-			Name:    "invocation",
-			Aliases: []string{"wi", "invocations", "workflow-invocation", "wfi"},
-			Usage:   "Workflow Invocation-related commands",
-			Subcommands: []cli.Command{
-				{
-					Name:  "get",
-					Usage: "get <workflow-invocation-id> <task-invocation-id>",
-					Action: func(c *cli.Context) error {
-						u := parseUrl(c.GlobalString("url"))
-						client := createTransportClient(u)
-						wfiApi := workflow_invocation_api.New(client, strfmt.Default)
-						switch c.NArg() {
-						case 0:
-							// List workflows invocations
-							resp, err := wfiApi.List(workflow_invocation_api.NewListParams())
-							if err != nil {
-								panic(err)
-							}
-							wis := resp.Payload
-							sort.Strings(wis.Invocations)
-							var rows [][]string
-							for _, wfiId := range wis.Invocations {
-								resp, err := wfiApi.Get(workflow_invocation_api.NewGetParams().WithID(wfiId))
-								if err != nil {
-									panic(err)
-								}
-								wi := resp.Payload
-								updated := wi.Status.UpdatedAt.String()
-								created := wi.Metadata.CreatedAt.String()
-
-								rows = append(rows, []string{wfiId, wi.Spec.WorkflowID, string(wi.Status.Status),
-									created, updated})
-							}
-							table(os.Stdout, []string{"ID", "WORKFLOW", "STATUS", "CREATED", "UPDATED"}, rows)
-						case 1:
-							// Get Workflow invocation
-							wfiId := c.Args().Get(0)
-							resp, err := wfiApi.Get(workflow_invocation_api.NewGetParams().WithID(wfiId))
-							if err != nil {
-								panic(err)
-							}
-							wfi := resp.Payload
-							b, err := yaml.Marshal(wfi)
-							if err != nil {
-								panic(err)
-							}
-							fmt.Printf("%v\n", string(b))
-						case 2:
-							fallthrough
-						default:
-							wfiId := c.Args().Get(0)
-							taskId := c.Args().Get(1)
-							resp, err := wfiApi.Get(workflow_invocation_api.NewGetParams().WithID(wfiId))
-							if err != nil {
-								panic(err)
-							}
-							wfi := resp.Payload
-							ti, ok := wfi.Status.Tasks[taskId]
-							if !ok {
-								fmt.Println("Task invocation not found.")
-								return nil
-							}
-							b, err := yaml.Marshal(ti)
-							if err != nil {
-								panic(err)
-							}
-							fmt.Printf("%v\n", string(b))
-						}
-
-						return nil
-					},
-				},
-				{
-					Name:  "status",
-					Usage: "status <workflow-invocation-id> ",
-					Action: func(c *cli.Context) error {
-						if c.NArg() < 1 {
-							fmt.Println("Need workflow invocation id")
-							return nil
-						}
-						wfiId := c.Args().Get(0)
-						u := parseUrl(c.GlobalString("url"))
-						client := createTransportClient(u)
-						wfApi := workflow_api.New(client, strfmt.Default)
-						wfiApi := workflow_invocation_api.New(client, strfmt.Default)
-
-						wfiResp, err := wfiApi.Get(workflow_invocation_api.NewGetParams().WithID(wfiId))
-						if err != nil {
-							panic(err)
-						}
-						wfi := wfiResp.Payload
-
-						wfResp, err := wfApi.Get0(workflow_api.NewGet0Params().WithID(wfi.Spec.WorkflowID))
-						if err != nil {
-							panic(err)
-						}
-						wf := wfResp.Payload
-
-						wfiUpdated := wfi.Status.UpdatedAt.String()
-						wfiCreated := wfi.Metadata.CreatedAt.String()
-						table(os.Stdout, nil, [][]string{
-							{"ID", wfi.Metadata.ID},
-							{"WORKFLOW_ID", wfi.Spec.WorkflowID},
-							{"CREATED", wfiCreated},
-							{"UPDATED", wfiUpdated},
-							{"STATUS", string(wfi.Status.Status)},
-						})
-						fmt.Println()
-
-						rows := [][]string{}
-						rows = collectStatus(wf.Spec.Tasks, wfi.Status.Tasks, rows)
-						rows = collectStatus(wfi.Status.DynamicTasks, wfi.Status.Tasks, rows)
-
-						table(os.Stdout, []string{"TASK", "STATUS", "STARTED", "UPDATED"}, rows)
-						return nil
-					},
-				},
-			},
-		},
+		cmdConfig,
+		cmdStatus,
+		cmdParse,
+		cmdWorkflow,
+		cmdInvocation,
 	}
 
 	app.Run(os.Args)
-}
-func collectStatus(tasks map[string]models.Task, taskStatus map[string]models.TaskInvocation, rows [][]string) [][]string {
-	ids := []string{}
-	for id := range tasks {
-		ids = append(ids, id)
-	}
-	sort.Strings(ids)
-
-	for _, id := range ids {
-		status := types.TaskInvocationStatus_SCHEDULED.String()
-		updated := ""
-		started := ""
-
-		taskStatus, ok := taskStatus[id]
-		if ok {
-			status = string(taskStatus.Status.Status)
-			started = taskStatus.Metadata.CreatedAt.String()
-			updated = taskStatus.Metadata.CreatedAt.String()
-		}
-
-		rows = append(rows, []string{id, status, started, updated})
-	}
-	return rows
 }
 
 func table(writer io.Writer, headings []string, rows [][]string) {

--- a/cmd/wfcli/parse.go
+++ b/cmd/wfcli/parse.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/fission/fission-workflows/pkg/api/workflow/parse/yaml"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/urfave/cli"
+)
+
+var cmdParse = cli.Command{
+	Name:        "parse",
+	Aliases:     []string{"p"},
+	Usage:       "parse <path-to-yaml> ",
+	Description: "Parse YAML definitions to the executable JSON format (deprecated)",
+	Action: func(c *cli.Context) error {
+
+		if c.NArg() == 0 {
+			panic("Need a path to a yaml workflow definition")
+		}
+
+		for _, path := range c.Args() {
+
+			fnName := strings.TrimSpace(path)
+
+			f, err := os.Open(fnName)
+			if err != nil {
+				panic(err)
+			}
+
+			wfDef, err := yaml.Parse(f)
+			if err != nil {
+				panic(err)
+			}
+
+			wfSpec, err := yaml.Transform(wfDef)
+			if err != nil {
+				panic(err)
+			}
+
+			marshal := jsonpb.Marshaler{
+				Indent: "  ",
+			}
+			jsonWf, err := marshal.MarshalToString(wfSpec)
+			if err != nil {
+				panic(err)
+			}
+
+			fmt.Println(jsonWf)
+		}
+		return nil
+	},
+}

--- a/cmd/wfcli/status.go
+++ b/cmd/wfcli/status.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/fission/fission-workflows/cmd/wfcli/swagger-client/client/admin_api"
+	"github.com/go-openapi/strfmt"
+	"github.com/urfave/cli"
+)
+
+var cmdStatus = cli.Command{
+	Name:    "status",
+	Aliases: []string{"s"},
+	Usage:   "Check cluster status",
+	Action: func(c *cli.Context) error {
+		u := parseUrl(c.GlobalString("url"))
+		client := createTransportClient(u)
+		adminApi := admin_api.New(client, strfmt.Default)
+
+		resp, err := adminApi.Status(admin_api.NewStatusParams())
+		if err != nil {
+			panic(err)
+		}
+		fmt.Printf(resp.Payload.Status)
+
+		return nil
+	},
+}

--- a/cmd/wfcli/workflow.go
+++ b/cmd/wfcli/workflow.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/fission/fission-workflows/cmd/wfcli/swagger-client/client/workflow_api"
+	"github.com/fission/fission-workflows/pkg/api/workflow/parse/yaml"
+	"github.com/go-openapi/strfmt"
+	"github.com/urfave/cli"
+)
+
+var cmdWorkflow = cli.Command{
+	Name:    "workflow",
+	Aliases: []string{"wf", "workflows"},
+	Usage:   "Workflow-related commands",
+	Subcommands: []cli.Command{
+		{
+			Name:  "get",
+			Usage: "get <workflow-id> <task-id>",
+			Action: func(c *cli.Context) error {
+				u := parseUrl(c.GlobalString("url"))
+				client := createTransportClient(u)
+				wfApi := workflow_api.New(client, strfmt.Default)
+				switch c.NArg() {
+				case 0:
+					// List workflows
+					resp, err := wfApi.List0(workflow_api.NewList0Params())
+					if err != nil {
+						panic(err)
+					}
+					wfs := resp.Payload.Workflows
+					sort.Strings(wfs)
+					var rows [][]string
+					for _, wfId := range wfs {
+						resp, err := wfApi.Get0(workflow_api.NewGet0Params().WithID(wfId))
+						if err != nil {
+							panic(err)
+						}
+						wf := resp.Payload
+						updated := wf.Status.UpdatedAt.String()
+						created := wf.Metadata.CreatedAt.String()
+
+						rows = append(rows, []string{wfId, wf.Spec.Name, string(wf.Status.Status),
+							created, updated})
+					}
+					table(os.Stdout, []string{"ID", "NAME", "STATUS", "CREATED", "UPDATED"}, rows)
+				case 1:
+					// Get Workflow
+					wfId := c.Args().Get(0)
+					println(wfId)
+					resp, err := wfApi.Get0(workflow_api.NewGet0Params().WithID(wfId))
+					if err != nil {
+						panic(err)
+					}
+					b, err := yaml.Marshal(resp.Payload)
+					if err != nil {
+						panic(err)
+					}
+					fmt.Printf("%v\n", string(b))
+				case 2:
+					// Get Workflow task
+					fallthrough
+				default:
+					wfId := c.Args().Get(0)
+					taskId := c.Args().Get(1)
+					resp, err := wfApi.Get0(workflow_api.NewGet0Params().WithID(wfId))
+					if err != nil {
+						panic(err)
+					}
+					wf := resp.Payload
+					task, ok := wf.Spec.Tasks[taskId]
+					if !ok {
+						fmt.Println("Task not found.")
+						return nil
+					}
+					b, err := yaml.Marshal(task)
+					if err != nil {
+						panic(err)
+					}
+					fmt.Printf("%v\n", string(b))
+				}
+
+				return nil
+			},
+		},
+	},
+}

--- a/pkg/controller/invocation.go
+++ b/pkg/controller/invocation.go
@@ -40,7 +40,7 @@ type InvocationController struct {
 	workQueue chan Action
 
 	// Queued keeps track of which invocations still have actions in the workQueue
-	states    map[string]ControlState
+	states map[string]ControlState
 	// TODO add active cache
 }
 

--- a/pkg/controller/meta.go
+++ b/pkg/controller/meta.go
@@ -9,8 +9,8 @@ import (
 
 	"io"
 
-	"github.com/fission/fission-workflows/pkg/fes"
 	"errors"
+	"github.com/fission/fission-workflows/pkg/fes"
 )
 
 const (

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -1,10 +1,10 @@
 package controller
 
 import (
-	"github.com/fission/fission-workflows/pkg/fes"
-	"time"
-	"github.com/sirupsen/logrus"
 	"context"
+	"github.com/fission/fission-workflows/pkg/fes"
+	"github.com/sirupsen/logrus"
+	"time"
 )
 
 const (
@@ -15,7 +15,7 @@ const (
 )
 
 var log = logrus.New().WithFields(logrus.Fields{
-	"component":      "controller",
+	"component": "controller",
 })
 
 type Controller interface {

--- a/pkg/controller/workflow.go
+++ b/pkg/controller/workflow.go
@@ -7,6 +7,7 @@ import (
 
 	"context"
 
+	"fmt"
 	"github.com/fission/fission-workflows/pkg/api/workflow"
 	"github.com/fission/fission-workflows/pkg/fes"
 	"github.com/fission/fission-workflows/pkg/types"
@@ -14,7 +15,6 @@ import (
 	"github.com/fission/fission-workflows/pkg/util/backoff"
 	"github.com/fission/fission-workflows/pkg/util/labels"
 	"github.com/fission/fission-workflows/pkg/util/pubsub"
-	"fmt"
 )
 
 var wfLog = log.WithField("controller", "controller-wf")
@@ -105,7 +105,7 @@ func (ctr *WorkflowController) HandleTick() error {
 		if !ok {
 			wfLog.WithField("wfEntity", wfEntity).WithField("type", reflect.TypeOf(wfEntity)).
 				Error("Unexpected type in wfCache")
-			panic(fmt.Sprintf("unexpected type '%v' in wfCache", reflect.TypeOf(wfEntity)));
+			panic(fmt.Sprintf("unexpected type '%v' in wfCache", reflect.TypeOf(wfEntity)))
 		}
 
 		err = ctr.evaluate(wf.Workflow)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-
 var log = logrus.WithField("component", "scheduler")
 
 type WorkflowScheduler struct {
@@ -18,7 +17,7 @@ type WorkflowScheduler struct {
 
 func (ws *WorkflowScheduler) Evaluate(request *ScheduleRequest) (*Schedule, error) {
 	ctxLog := log.WithFields(logrus.Fields{
-		"wfi":   request.Invocation.Metadata.Id,
+		"wfi": request.Invocation.Metadata.Id,
 	})
 
 	schedule := &Schedule{


### PR DESCRIPTION
Currently the CLI is a single, huge file containing all commands and utility functions. This PR breaks it up into multiple files, in which each command gets its own file. This should make the cli more readable and understandable.