### PR TITLE
Add improved graph and validation support

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 85c7264693e84b8352542e0018e4e3d609fdb4681b5435f38d8db7db1ed97def
-updated: 2018-02-12T11:02:55.971444+01:00
+hash: dbff9efd05e00f3d15b3a68fb92742fd6152cca30d16e41a628195a5b6471c0c
+updated: 2018-02-18T12:23:26.60748+01:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -69,7 +69,7 @@ imports:
   subpackages:
   - base64vlq
 - name: github.com/gogo/protobuf
-  version: 342cbe0a04158f6dcb03ca0079991a51a4248c02
+  version: 1adfc126b41513cc696b209667c8656ea7aac67c
   subpackages:
   - gogoproto
   - jsonpb
@@ -151,7 +151,7 @@ imports:
 - name: github.com/satori/go.uuid
   version: f58768cc1a7a7e77a3bd49e98cdd21419399b6a3
 - name: github.com/sirupsen/logrus
-  version: 68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a
+  version: d682213848ed68c0a260ca37d6dd5ace8423f5ba
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
@@ -204,6 +204,30 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
+- name: gonum.org/v1/gonum
+  version: 996b88e8f8941c9defdbb338bea5e239a230e742
+  repo: http://github.com/gonum/gonum
+  subpackages:
+  - blas
+  - blas/blas64
+  - blas/gonum
+  - floats
+  - graph
+  - graph/internal/linear
+  - graph/internal/ordered
+  - graph/internal/set
+  - graph/internal/uid
+  - graph/simple
+  - graph/topo
+  - graph/traverse
+  - internal/asm/c128
+  - internal/asm/f32
+  - internal/asm/f64
+  - internal/math32
+  - lapack
+  - lapack/gonum
+  - lapack/lapack64
+  - mat
 - name: google.golang.org/appengine
   version: 12d5545dc1cfa6047a286d5e853841b6471f4c19
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -9,7 +9,7 @@ import:
 - package: golang.org/x/text
   version: 88f656faf3f37f690df1a32515b479415e1a6769
 - package: github.com/sirupsen/logrus
-  version: 68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a
+  version: 1.0.4
 - package: github.com/urfave/cli
   version: ^1.18.1
 - package: github.com/gorilla/handlers
@@ -22,7 +22,6 @@ import:
   version: 0a4f71a498b7c4812f64969510bcb4eca251e33a
 - package: golang.org/x/net
   version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
-- package: google.golang.org/genproto
 - package: github.com/satori/go.uuid
   version: ^1.1.0
 - package: github.com/nats-io/go-nats
@@ -32,7 +31,7 @@ import:
 - package: github.com/nats-io/go-nats-streaming
   version: ^v0.3.4
 - package: github.com/gogo/protobuf
-  version: ^0.4.0
+  version: 1.0.0
   subpackages:
   - gogoproto
 - package: github.com/golang/glog
@@ -52,6 +51,13 @@ import:
 - package: golang.org/x/sync
   subpackages:
   - syncmap
+- package: gonum.org/v1/gonum
+  version: 996b88e8f8941c9defdbb338bea5e239a230e742
+  repo:    http://github.com/gonum/gonum
+  subpackages:
+  - graph
+  - graph/topo
+  - graph/simple
 testImport:
 - package: github.com/stretchr/testify
   version: ^1.1.4

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -5,7 +5,7 @@
 #
 
 # Configs
-FISSION_VERSION=0.4.1
+FISSION_VERSION=0.5.0
 FISSION_WORKFLOWS_VERSION=0.2.0
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/hack/minikube.sh
+++ b/hack/minikube.sh
@@ -40,11 +40,7 @@ eval $(minikube docker-env)
 # Install helm on cluster
 if ! helm list >/dev/null 2>&1 ; then
     echo "Installing helm..."
-    kubectl -n kube-system create sa tiller
-
-    kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-
-    helm init --service-account tiller
+    helm init
 
     printf "Waiting for Helm"
     until helm list >/dev/null 2>&1

--- a/hack/verify-workflows.sh
+++ b/hack/verify-workflows.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename '*/vendor/*' \
+      \) -prune \
+    \) -name '*.wf.yaml'
+}
+
+TOOL="wfcli validate"
+bad_files=$(find_files | grep -v '.glide/cache' | xargs ${TOOL})
+if [[ -n "${bad_files}" ]]; then
+  echo "The following workflows are invalid: "
+  echo "${bad_files}"
+  exit 1
+fi

--- a/pkg/types/graph/graph.go
+++ b/pkg/types/graph/graph.go
@@ -1,0 +1,199 @@
+package graph
+
+import (
+	"hash/fnv"
+
+	"github.com/fission/fission-workflows/pkg/types"
+	"gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+var (
+	hasher = fnv.New64a()
+)
+
+type LinkedNode interface {
+	graph.Node
+	Links() []int64
+}
+
+type TaskInstanceNode struct {
+	*types.TaskInstance
+}
+
+func (n *TaskInstanceNode) ID() int64 {
+	return createId(n.Task.Id)
+}
+
+func (n *TaskInstanceNode) Links() []int64 {
+	var links []int64
+	for k := range n.Task.Requires {
+		links = append(links, createId(k))
+	}
+	return links
+}
+
+type TaskSpecNode struct {
+	Id string
+	*types.TaskSpec
+}
+
+func (n *TaskSpecNode) Links() []int64 {
+	var links []int64
+	for k := range n.Requires {
+		links = append(links, createId(k))
+	}
+	return links
+}
+
+func (n *TaskSpecNode) ID() int64 {
+	return createId(n.Id)
+}
+
+type Iterator interface {
+	Get(ptr int) LinkedNode
+}
+
+type TaskInstanceIterator struct {
+	contents map[string]*types.TaskInstance
+	keys     []string
+}
+
+func NewTaskInstanceIterator(contents map[string]*types.TaskInstance) *TaskInstanceIterator {
+	var keys []string
+	for k := range contents {
+		keys = append(keys, k)
+	}
+	return &TaskInstanceIterator{
+		contents: contents,
+		keys:     keys,
+	}
+}
+
+func (ti *TaskInstanceIterator) Get(ptr int) LinkedNode {
+	if len(ti.keys) > ptr {
+		return &TaskInstanceNode{
+			TaskInstance: ti.contents[ti.keys[ptr]],
+		}
+	}
+	return nil
+}
+
+type TaskSpecIterator struct {
+	contents map[string]*types.TaskSpec
+	keys     []string
+}
+
+func (ts *TaskSpecIterator) Get(ptr int) LinkedNode {
+	if len(ts.keys) > ptr {
+		return &TaskSpecNode{
+			TaskSpec: ts.contents[ts.keys[ptr]],
+			Id:       ts.keys[ptr],
+		}
+	}
+	return nil
+}
+
+func NewTaskSpecIterator(contents map[string]*types.TaskSpec) *TaskSpecIterator {
+	var keys []string
+	for k := range contents {
+		keys = append(keys, k)
+	}
+	return &TaskSpecIterator{
+		contents: contents,
+		keys:     keys,
+	}
+}
+
+func Parse(it Iterator) graph.Directed {
+	depGraph := simple.NewDirectedGraph()
+	// Add Nodes
+	for ptr := 0; it.Get(ptr) != nil; ptr += 1 {
+		depGraph.AddNode(it.Get(ptr))
+	}
+
+	// Add dependencies
+	for ptr := 0; it.Get(ptr) != nil; ptr += 1 {
+		n := it.Get(ptr)
+		if n.Links() != nil {
+			for _, dep := range n.Links() {
+				depNode := depGraph.Node(dep)
+				if depNode != nil {
+					e := depGraph.NewEdge(depNode, n)
+					depGraph.SetEdge(e)
+				}
+			}
+		}
+	}
+
+	// Temporary: Alter the dependencies of dynamic task dependents
+	// This will eventually be moved into the eventstore implementation in the form of a
+	// middleware, to avoid having to recalculate the graph.
+	deps := map[int64]map[string]*types.TaskDependencyParameters{}
+	for _, v := range depGraph.Nodes() {
+		switch n := v.(type) {
+		case *TaskSpecNode:
+			deps[n.ID()] = n.Requires
+		case *TaskInstanceNode:
+			deps[n.ID()] = n.Task.Requires
+		}
+	}
+	for _, v := range depGraph.Nodes() {
+		injectDynamicTask(depGraph, v, deps)
+	}
+
+	return depGraph
+}
+
+func Roots(g graph.Directed) []graph.Node {
+	var roots []graph.Node
+	for _, n := range g.Nodes() {
+		in := g.To(n)
+		if len(in) == 0 {
+			roots = append(roots, n)
+		}
+	}
+	return roots
+}
+
+func createId(s string) int64 {
+	hasher.Reset()
+	hasher.Write([]byte(s))
+	return int64(hasher.Sum64())
+}
+
+func injectDynamicTask(depGraph *simple.DirectedGraph, dynamic graph.Node,
+	nodeRequires map[int64]map[string]*types.TaskDependencyParameters) {
+
+	// find parent id
+	var parentTaskId string
+	var found bool
+	for dep, params := range nodeRequires[dynamic.ID()] {
+		if params != nil && params.Type == types.TaskDependencyParameters_DYNAMIC_OUTPUT {
+			parentTaskId = dep
+			found = true
+			break
+		}
+	}
+	if !found {
+		return
+	}
+
+	// Add edges from the dynamic task to all nodes depending on the parent.
+	for nodeId, deps := range nodeRequires {
+		if _, ok := deps[parentTaskId]; ok && nodeId != dynamic.ID() {
+			depNode := depGraph.Node(nodeId)
+			depGraph.SetEdge(depGraph.NewEdge(dynamic, depNode))
+		}
+	}
+}
+
+func Get(g graph.Graph, id string) graph.Node {
+	idHash := createId(id)
+	for _, v := range g.Nodes() {
+		if v.ID() == idHash {
+			return v
+		}
+	}
+	return nil
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -15,6 +15,7 @@ const (
 	INPUT_METHOD       = "method"
 
 	typedValueShortMaxLen = 32
+	WorkflowApiVersion    = "v1"
 )
 
 // InvocationEvent
@@ -67,4 +68,11 @@ func (tv TypedValue) Short() string {
 
 func (m *Error) Error() string {
 	return m.Message
+}
+
+type TaskSpec = Task
+
+type TaskInstance struct {
+	Task       *TaskSpec
+	Invocation *TaskInvocation
 }

--- a/pkg/types/validate/validate.go
+++ b/pkg/types/validate/validate.go
@@ -1,0 +1,198 @@
+// Validate package contains validation functions for the common structures used in the
+// workflow engine, such as Workflows, Tasks, WorkflowInvocations, etc.
+package validate
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/fission/fission-workflows/pkg/types"
+	"github.com/fission/fission-workflows/pkg/types/graph"
+	"gonum.org/v1/gonum/graph/topo"
+)
+
+var (
+	ErrObjectEmpty                  = errors.New("no object provided")
+	ErrInvalidApiVersion            = errors.New("unknown API version")
+	ErrWorkflowWithoutTasks         = errors.New("workflow needs at least one task")
+	ErrUndefinedDependency          = errors.New("task contains undefined dependency")
+	ErrTaskIdMissing                = errors.New("task misses an id")
+	ErrTaskNotUnique                = errors.New("task is not unique")
+	ErrWorkflowWithoutStartTasks    = errors.New("workflow does not contain any start tasks (tasks with 0 dependencies)")
+	ErrTaskRequiresFnRef            = errors.New("task requires a function name")
+	ErrCircularDependency           = errors.New("workflow contains circular dependency")
+	ErrInvalidOutputTask            = errors.New("unknown output task")
+	ErrNoParentTaskDependency       = errors.New("dynamic task does not contain parent dependency")
+	ErrMultipleParentTaskDependency = errors.New("dynamic task contains multiple parent tasks")
+)
+
+type Error struct {
+	val  string
+	errs []error
+}
+
+// Note that this does not take nested Error's into account
+func (ie Error) Reasons() []error {
+	return ie.errs
+}
+
+func (ie Error) Error() string {
+	vt := ie.val
+	if len(vt) == 0 {
+		vt = "Value"
+	}
+	return fmt.Sprintf("%s is invalid", vt)
+}
+
+func (ie *Error) IsEmpty() bool {
+	return ie.errs == nil || len(ie.errs) == 0
+}
+
+func (ie Error) GetOrNil() error {
+	if ie.IsEmpty() {
+		return nil
+	} else {
+		return ie
+	}
+}
+
+func (ie *Error) append(err error) {
+	if err == nil {
+		return
+	}
+	if ie.errs == nil {
+		ie.errs = []error{err}
+	} else {
+		ie.errs = append(ie.errs, err)
+	}
+}
+
+// WorkflowSpec validates the Workflow Specification.
+func WorkflowSpec(spec *types.WorkflowSpec) error {
+	errs := Error{
+		val: "WorkflowSpec",
+	}
+
+	if spec == nil {
+		errs.append(ErrObjectEmpty)
+		return errs.GetOrNil()
+	}
+
+	if len(spec.ApiVersion) > 0 && !strings.EqualFold(spec.GetApiVersion(), types.WorkflowApiVersion) {
+		errs.append(fmt.Errorf("%v: '%v'", ErrInvalidApiVersion, spec.GetApiVersion()))
+	}
+
+	if len(spec.Tasks) == 0 {
+		errs.append(ErrWorkflowWithoutTasks)
+	}
+
+	_, ok := spec.Tasks[spec.OutputTask]
+	if !ok {
+		errs.append(ErrInvalidOutputTask)
+	}
+
+	refTable := map[string]*types.TaskSpec{}
+	for taskId, task := range spec.Tasks {
+		if len(taskId) == 0 {
+			errs.append(ErrTaskIdMissing)
+		}
+
+		errs.append(TaskSpec(task))
+
+		_, ok := refTable[taskId]
+		if ok {
+			errs.append(fmt.Errorf("%v: '%v'", ErrTaskNotUnique, taskId))
+		}
+		refTable[taskId] = task
+	}
+
+	// Dependency testing
+	var startTasks []*types.TaskSpec
+	for taskId, task := range spec.GetTasks() {
+		if len(task.Requires) == 0 {
+			startTasks = append(startTasks, task)
+		}
+
+		// Check for undefined dependencies
+		for depName := range task.Requires {
+			if _, ok := refTable[depName]; !ok {
+				errs.append(fmt.Errorf("%v: '%v->%v'", ErrUndefinedDependency, taskId, depName))
+			}
+		}
+	}
+
+	// Check for circular dependencies
+	dg := graph.Parse(graph.NewTaskSpecIterator(spec.Tasks))
+	if len(topo.DirectedCyclesIn(dg)) > 0 {
+		errs.append(ErrCircularDependency)
+	}
+
+	// Check if there are starting points
+	if len(startTasks) == 0 {
+		errs.append(ErrWorkflowWithoutStartTasks)
+	}
+
+	return errs.GetOrNil()
+}
+
+func TaskSpec(task *types.TaskSpec) error {
+	errs := Error{
+		val: "TaskSpec",
+	}
+
+	if len(task.FunctionRef) == 0 {
+		errs.append(ErrTaskRequiresFnRef)
+	}
+
+	return errs.GetOrNil()
+}
+
+func DynamicTaskSpec(task *types.TaskSpec) error {
+	err := TaskSpec(task)
+	if err != nil {
+		return err
+	}
+	errs := Error{
+		val: "TaskSpec.dynamic",
+	}
+
+	// Check if there is a parent link
+	var parents int
+	for _, params := range task.Requires {
+		if params.Type == types.TaskDependencyParameters_DYNAMIC_OUTPUT {
+			parents += 1
+		}
+	}
+	if parents == 0 {
+		errs.append(ErrNoParentTaskDependency)
+	} else if parents > 1 {
+		errs.append(ErrMultipleParentTaskDependency)
+	}
+	return errs.GetOrNil()
+}
+
+// Format is an utility for printing the error hierarchies of Error
+func Format(rawErr error) string {
+	switch err := rawErr.(type) {
+	case Error:
+		result := err.Error() + "\n"
+		for _, reason := range err.Reasons() {
+			var formatted string
+			switch t := reason.(type) {
+			case Error:
+				reasons := Format(t)
+				reasons = strings.Replace(reasons, "\n", "\n  ", -1)
+				reasons = reasons[:len(reasons)-2]
+				formatted = fmt.Sprintf("- %v\n", reasons)
+			default:
+				formatted = fmt.Sprintf("- %v\n", reason)
+			}
+			result += formatted
+		}
+
+		return strings.TrimSpace(result)
+	default:
+		return fmt.Sprintf("%v", err)
+	}
+}

--- a/pkg/types/validate/validate_test.go
+++ b/pkg/types/validate/validate_test.go
@@ -1,0 +1,67 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/fission/fission-workflows/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func validSpec() *types.WorkflowSpec {
+	return &types.WorkflowSpec{
+		ApiVersion: types.WorkflowApiVersion,
+		OutputTask: "last",
+		Tasks: map[string]*types.TaskSpec{
+			"first": {
+				FunctionRef: "fn",
+			},
+			"middle": {
+				FunctionRef: "fn",
+				Requires: map[string]*types.TaskDependencyParameters{
+					"first": nil,
+				},
+			},
+			"last": {
+				FunctionRef: "fn",
+				Requires: map[string]*types.TaskDependencyParameters{
+					"middle": nil,
+				},
+			},
+		},
+	}
+}
+
+func TestWorkflowSpecValid(t *testing.T) {
+	err := WorkflowSpec(validSpec())
+	assert.NoError(t, err, Format(err))
+}
+
+func TestWorkflowSpecInvalidApiVersion(t *testing.T) {
+	spec := validSpec()
+	spec.ApiVersion = "nonExistent"
+	assert.Error(t, WorkflowSpec(spec))
+}
+
+func TestWorkflowSpecInvalidOutputTask(t *testing.T) {
+	spec := validSpec()
+	spec.OutputTask = "nonExistent"
+	assert.Error(t, WorkflowSpec(spec))
+}
+
+func TestWorkflowSpecNoTasks(t *testing.T) {
+	spec := validSpec()
+	spec.Tasks = map[string]*types.TaskSpec{}
+	assert.Error(t, WorkflowSpec(spec))
+}
+
+//func TestWorkflowSpecInvalidRequires(t *testing.T) {
+//	spec := validSpec()
+//	spec.Tasks["middle"].AddDependency("nonExistentDep")
+//	assert.Error(t, WorkflowSpec(spec))
+//}
+//
+//func TestWorkflowSpecInvalidCircularDependency(t *testing.T) {
+//	spec := validSpec()
+//	spec.Tasks["first"].AddDependency("last")
+//	assert.Error(t, WorkflowSpec(spec))
+//}


### PR DESCRIPTION
This PR adds two related packages. First this change introduces a Gonum-based graph implementation for improved performance and easier access to advanced, well-tested graph functionality. In a future PR the implicit graph implementation in the scheduler will be replaced with this one.

Partly using this new graphing support to detect circular dependencies, this PR also adds a new validation package. It aims to replace the existing ad-hoc implementation with a more structured, and consistent API. Likewise, in a future PR the current validation will be replaced with this `validation` package.