### PR TITLE
Improve (docker) build scripts

### DIFF
--- a/.Dockerignore
+++ b/.Dockerignore
@@ -1,0 +1,4 @@
+vendor
+local
+Docs
+data

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 vendor/
 bazel-*
+data/
 
 *.tgz
+/fission-workflows-bundle
+/wfcli

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ install:
 - sudo apt-get -y install google-cloud-sdk
 - sudo apt-get -y install coreutils
 - test/e2e/travis-kube-setup.sh
-- glide -h > /dev/null || go get github.com/Masterminds/glide
 # Needed for some integration tests
+- glide -h > /dev/null || go get github.com/Masterminds/glide
 - nats-streaming-server -h > /dev/null || go get github.com/nats-io/nats-streaming-server
 
 before_script:
@@ -48,6 +48,7 @@ script:
 # Unit and Integration tests
 - test/runtests.sh
 # End-to-end tests
+# TODO no need to rebuild (tag images with test ID and check if they exist before starting to rebuild)
 - test/e2e/travis-buildtest.sh
 
 notifications:

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,2 +1,0 @@
-fission-workflows-bundle
-wfcli

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,0 +1,22 @@
+# To run (from repo root): docker build -t fission -f ./build/Dockerfile .
+ARG NOBUILD
+ARG GOLANG_VERSION=1.9.4
+FROM golang:$GOLANG_VERSION AS builder
+
+WORKDIR /go/src/github.com/fission/fission-workflows
+
+COPY . .
+
+RUN if [ "_$NOBUILD" = "_" ] ; then \
+        go get github.com/Masterminds/glide; \
+        glide install; \
+        build/build-linux.sh; \
+    else \
+        echo "NOBUILD provided; assuming binaries exist in context."; \
+    fi
+
+# Bundle image
+FROM scratch
+
+COPY --from=builder /go/src/github.com/fission/fission-workflows/fission-workflows-bundle /fission-workflows-bundle
+COPY --from=builder /go/src/github.com/fission/fission-workflows/wfcli /wfcli

--- a/build/build-env/Dockerfile
+++ b/build/build-env/Dockerfile
@@ -1,6 +1,14 @@
-FROM fission/builder:0.4.1
+ARG BUNDLE_IMAGE=fission-workflows-bundle
+ARG BUNDLE_TAG=latest
+ARG FISSION_BUILDER_IMAGE=fission/builder
+ARG FISSION_TAG=0.4.1
 
-ADD wfcli /usr/local/bin/wfcli
+# Builders
+FROM $BUNDLE_IMAGE:$BUNDLE_TAG as workflows-bundle
+
+FROM $FISSION_BUILDER_IMAGE:$FISSION_TAG
+
+COPY --from=workflows-bundle /wfcli /usr/local/bin/wfcli
 ADD defaultBuild.sh /usr/local/bin/defaultBuild
 
 EXPOSE 8001

--- a/build/build-osx.sh
+++ b/build/build-osx.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+GOOS=darwin GOARCH=386 CGO_ENABLED=0 go build -o wfcli-osx github.com/fission/fission-workflows/cmd/wfcli/
+GOOS=darwin GOARCH=386 CGO_ENABLED=0 go build -o fission-workflows-bundle-osx github.com/fission/fission-workflows/cmd/fission-workflows-bundle/

--- a/build/build-windows.sh
+++ b/build/build-windows.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -o fission-workflows-bundle-windows.exe github.com/fission/fission-workflows/cmd/fission-workflows-bundle/
+GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -o wfcli-windows.exe github.com/fission/fission-workflows/cmd/wfcli/

--- a/build/bundle/Dockerfile
+++ b/build/bundle/Dockerfile
@@ -1,2 +1,0 @@
-FROM alpine:3.5
-ADD fission-workflows-bundle /

--- a/build/runtime-env/Dockerfile
+++ b/build/runtime-env/Dockerfile
@@ -1,6 +1,14 @@
-FROM alpine:3.5
+ARG BUNDLE_IMAGE=fission-workflows-bundle
+ARG BUNDLE_TAG=latest
+ARG FISSION_BUILDER_IMAGE=fission/builder
+ARG FISSION_TAG=0.4.1
 
-ADD fission-workflows-bundle /
+# Builders
+FROM $BUNDLE_IMAGE:$BUNDLE_TAG as workflows-bundle
+
+FROM scratch
+
+COPY --from=workflows-bundle /fission-workflows-bundle /fission-workflows-bundle
 
 EXPOSE 8888
 

--- a/build/wfcli/Dockerfile
+++ b/build/wfcli/Dockerfile
@@ -1,0 +1,10 @@
+ARG BUNDLE_IMAGE=fission-workflows-bundle
+ARG BUNDLE_TAG=latest
+FROM $BUNDLE_IMAGE:$BUNDLE_TAG as workflows-bundle
+
+FROM scratch
+
+COPY --from=workflows-bundle /wfcli /wfcli
+
+ENTRYPOINT ["/wfcli"]
+CMD ["-h"]

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -1,14 +1,20 @@
 #!/usr/bin/env bash
 
+set -e
+
 #
 # release.sh - Generate all artifacts for a release
 #
 
 # wfcli
-echo "Building wfcli..."
-GOOS=darwin GOARCH=386 CGO_ENABLED=0 go build -o wfcli-osx github.com/fission/fission-workflows/cmd/wfcli/
-GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -o wfcli-windows.exe github.com/fission/fission-workflows/cmd/wfcli/
-GOOS=linux GOARCH=386 CGO_ENABLED=0 go build -o wfcli-linux github.com/fission/fission-workflows/cmd/wfcli/
+echo "Building linux binaries..."
+build/build-linux.sh
+mv fission-workflows-bundle fission-workflows-bundle-linux
+mv wfcli wfcli-linux
+echo "Building windows binaries..."
+build/build-windows.sh
+echo "Building osx binaries..."
+build/build-osx.sh
 
 # Deployments
 echo "Packaging chart..."

--- a/test/e2e/buildtest.sh
+++ b/test/e2e/buildtest.sh
@@ -108,17 +108,17 @@ emph "Fission deployed!"
 #
 # Build
 #
-emph "Building binaries..."
-bash ${ROOT}/build/build-linux.sh
-
-# Ensure cli is in path
-emph "Copying wfcli to '${BIN_DIR}/wfcli'..."
-cp wfcli ${BIN_DIR}/wfcli
-wfcli -h > /dev/null
-
 # Build docker images
 emph "Building images..."
 bash ${ROOT}/build/docker.sh ${DOCKER_REPO} ${TAG}
+
+# Ensure cli is in path
+emph "Copying wfcli to '${BIN_DIR}/wfcli'..."
+bundleImage=${DOCKER_REPO}/fission-workflows-bundle:${TAG}
+bundleContainer=$(docker create ${bundleImage} tail /dev/null)
+docker cp ${bundleContainer}:/wfcli ${BIN_DIR}/wfcli
+docker rm -v ${bundleContainer}
+wfcli -h > /dev/null
 
 # Publish to gcloud
 emph "Pushing images to container registry..."


### PR DESCRIPTION
Removed the need for passing and copying the binaries everywhere by using docker multi-stage builds. Additionally, the specialized images (e.g. the ones adapted for Fission environment spec depend on the core bundle image.