### PR TITLE
Bump controller tick speed to 100 ms

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	TickInterval = time.Duration(1) * time.Second
+	TickInterval = time.Duration(100) * time.Millisecond
 )
 
 var (

--- a/pkg/controller/invocation/controller.go
+++ b/pkg/controller/invocation/controller.go
@@ -210,7 +210,7 @@ func (cr *Controller) Evaluate(invocationId string) {
 		defer evalState.Free()
 	default:
 		// TODO provide option to wait for a lock
-		wfiLog.Infof("Failed to obtain access to invocation %s", invocationId)
+		wfiLog.Debugf("Failed to obtain access to invocation %s", invocationId)
 		return
 	}
 	log.Debugf("evaluating invocation %s", invocationId)

--- a/pkg/controller/workflow/controller.go
+++ b/pkg/controller/workflow/controller.go
@@ -141,7 +141,7 @@ func (c *Controller) Evaluate(workflowId string) {
 		defer evalState.Free()
 	default:
 		// TODO provide option to wait for a lock
-		wfLog.Infof("Failed to obtain access to workflow %s", workflowId)
+		wfLog.Debugf("Failed to obtain access to workflow %s", workflowId)
 		return
 	}
 	wfLog.Debugf("evaluating workflow %s", workflowId)


### PR DESCRIPTION
This PR bumps the controller tick speed from 1 sec to 100 ms and removes the verbose "not being able to access" messages from the logs.