### PR TITLE
Add installation instructions for wfcli client

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -64,4 +64,52 @@ fission route create --method GET --url /fortunewhale --function fortunewhale
 # Invoke the workflow with an HTTP request:
 #
 curl ${FISSION_ROUTER}/fortunewhale
-``` 
+```
+
+### wfcli client (optional)
+To use Fission Workflows there is no need to learn any other client other than the one you already use for function invocation - after all, a workflow is just another function.
+However, in many cases it is useful to have more insight in and control over the behaviour of the workflows (for example when developing/debugging workflows).
+To get these additional capabilities and insight, you can use the `wfcli` client.
+
+It has the following features:
+- Get insight into workflow and invocations statuses.
+- Start, and cancel workflow invocation.
+- Perform administrative or debugging actions: for example halting and resuming the engine.
+- validating workflow definitions locally.
+
+#### Installation
+To install `wfcli` either get a version of the binary from the [releases](https://github.com/fission/fission-workflows/releases).
+For example, to download and install version 0.2.0,  assuming that you use OS X:
+```bash
+curl -o wfcli https://github.com/fission/fission-workflows/releases/download/0.2.0/wfcli-osx
+sudo mv ./wfcli /usr/local/bin
+```
+
+Or install the latest, edge version with Go:
+```bash
+go get -u github.com/fission/fission-workflows/cmd/wfcli
+```
+
+The `wfcli` client uses the `FISSION_URL` environment variable to find the Fission controller server to use as a proxy to the workflow apiserver.
+By default `wfcli` uses ttp://localhost:31313 as the location of the Fission controller.
+
+#### Examples
+Get all defined workflows loaded in the workflow engine:
+```bash
+wfcli workflows get
+```
+
+Get all workflow invocations:
+```bash
+wfcli invocations get
+```
+
+Get a specific task execution in a specific 
+```bash
+wfcli invocations <invocation-id> <task-id>
+```
+
+Cancel a workflow invocation
+```bash 
+wfcli invocations cancel <invocation-id>
+```


### PR DESCRIPTION
This PR adds (installation) documentation for the `wfcli` tool. 