### PR TITLE
Fix bash variable errors at workflow builder cmd

### DIFF
--- a/build/build-env/defaultBuild.sh
+++ b/build/build-env/defaultBuild.sh
@@ -20,9 +20,9 @@ if [[ -f ${SRC_PKG} ]] ; then
 elif [[ -d ${SRC_PKG} ]] ; then
     # Package is an archive
     mkdir -p ${DEPLOY_PKG}
-    for wf in ${SRC_PKG}/*.yaml ; do
-        dst=$(basename wf)
-        parse ${wf} > ${DEPLOY_PKG}/dst
+    for wf in ${SRC_PKG}/*.wf.yaml ; do
+        dst=$(basename ${wf})
+        parse ${wf} ${DEPLOY_PKG}/${dst}
     done
 else
     echo "Invalid file type: '${SRC_PKG}'"


### PR DESCRIPTION
Fixes #139 
* Fix variable errors, use $
* Only scan for `*.wf.yaml` files as archive may contain other `*.yaml` files (happened in real use case)
* Fix parse call by removing wrong `>` redirection call