### PR TITLE
Match validation errors to IllegalArgument HTTP statuses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,13 +3,11 @@ bazel-*
 data/
 
 *.tgz
-/fission-workflows-bundle
-/fission-workflows-bundle-osx
-/fission-workflows-bundle-windows
-/wfcli
-/wfcli-osx
-/wfcli-windows
 __pycache__/
 *.pyc
 
 revive.toml
+
+
+wfcli*
+fission-workflows-bundle*

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -1,2 +1,0 @@
-// Package api contains all functionality to controlling workflows, tasks, and invocations.
-package api

--- a/pkg/api/dynamic.go
+++ b/pkg/api/dynamic.go
@@ -27,14 +27,17 @@ func (ap *Dynamic) AddDynamicFlow(invocationID string, parentTaskID string, flow
 	if err := validate.Flow(flow); err != nil {
 		return err
 	}
-	if flow.Workflow() != nil {
+	switch flow.Type() {
+	case typedvalues.Workflow:
 		return ap.addDynamicWorkflow(invocationID, parentTaskID, flow.Workflow(), &types.TaskSpec{})
+	case typedvalues.Task:
+		return ap.addDynamicTask(invocationID, parentTaskID, flow.Task())
+	default:
+		panic("validated flow was still empty")
 	}
-	return ap.addDynamicTask(invocationID, parentTaskID, flow.Task())
 }
 
 func (ap *Dynamic) addDynamicTask(invocationID string, parentTaskID string, taskSpec *types.TaskSpec) error {
-
 	// Transform TaskSpec into WorkflowSpec
 	// TODO dedup workflows
 	// TODO indicate relation with workflow somehow?

--- a/pkg/api/invocation.go
+++ b/pkg/api/invocation.go
@@ -57,7 +57,7 @@ func (ia *Invocation) Invoke(invocation *types.WorkflowInvocationSpec) (string, 
 // become ABORTED. If the API fails to append the event to the event store, it will return an error.
 func (ia *Invocation) Cancel(invocationID string) error {
 	if len(invocationID) == 0 {
-		return errors.New("invocationID is required")
+		return validate.NewError("invocationID", errors.New("id should not be empty"))
 	}
 
 	err := ia.es.Append(&fes.Event{
@@ -77,7 +77,7 @@ func (ia *Invocation) Cancel(invocationID string) error {
 // If the API fails to append the event to the event store, it will return an error.
 func (ia *Invocation) Complete(invocationID string, output *types.TypedValue) error {
 	if len(invocationID) == 0 {
-		return errors.New("invocationID is required")
+		return validate.NewError("invocationID", errors.New("id should not be empty"))
 	}
 
 	data, err := proto.Marshal(&types.WorkflowInvocationStatus{
@@ -101,7 +101,7 @@ func (ia *Invocation) Complete(invocationID string, output *types.TypedValue) er
 // If the API fails to append the event to the event store, it will return an error.
 func (ia *Invocation) Fail(invocationID string, errMsg error) error {
 	if len(invocationID) == 0 {
-		return errors.New("invocationID is required")
+		return validate.NewError("invocationID", errors.New("id should not be empty"))
 	}
 
 	var msg string
@@ -128,7 +128,7 @@ func (ia *Invocation) Fail(invocationID string, errMsg error) error {
 // The error can be a validate.Err, proto marshall error, or a fes error.
 func (ia *Invocation) AddTask(invocationID string, task *types.Task) error {
 	if len(invocationID) == 0 {
-		return errors.New("invocationID is required")
+		return validate.NewError("invocationID", errors.New("id should not be empty"))
 	}
 	err := validate.Task(task)
 	if err != nil {

--- a/pkg/api/task.go
+++ b/pkg/api/task.go
@@ -140,10 +140,10 @@ func (ap *Task) Invoke(spec *types.TaskInvocationSpec) (*types.TaskInvocation, e
 // If the API fails to append the event to the event store, it will return an error.
 func (ap *Task) Fail(invocationID string, taskID string) error {
 	if len(invocationID) == 0 {
-		return errors.New("invocationID is required")
+		return validate.NewError("invocationID", errors.New("id should not be empty"))
 	}
 	if len(taskID) == 0 {
-		return errors.New("taskID is required")
+		return validate.NewError("taskID", errors.New("id should not be empty"))
 	}
 
 	return ap.es.Append(&fes.Event{

--- a/pkg/api/workflow.go
+++ b/pkg/api/workflow.go
@@ -66,7 +66,7 @@ func (wa *Workflow) Create(workflow *types.WorkflowSpec) (string, error) {
 // If the API fails to append the event to the event store, it will return an error.
 func (wa *Workflow) Delete(workflowID string) error {
 	if len(workflowID) == 0 {
-		return errors.New("workflowID is required")
+		return validate.NewError("workflowID", errors.New("id should not be empty"))
 	}
 
 	return wa.es.Append(&fes.Event{

--- a/pkg/apiserver/admin.go
+++ b/pkg/apiserver/admin.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/net/context"
 )
 
+// Admin is responsible for all administrative functions related to managing the workflow engine.
 type Admin struct {
 	metaCtrl controller.MetaController
 }

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -1,0 +1,32 @@
+/*
+Package apiserver contains all request handlers for gRPC and HTTP servers.
+
+It has these top-level request handlers:
+	Admin	   - Administrative functionality related to managing the workflow engine.
+	Invocation - Functionality related to managing invocations.
+	Workflow   - functionality related to managing workflows.
+
+The purpose of this package is purely to provide handlers to gRPC and HTTP servers. Therefore,
+it should not contain any logic (validation, composition, etc.) related to the workflows,
+invocations or any other targets that it provides. All this logic should be placed in the actual
+packages that are responsible for the business logic, such as `api`.
+*/
+package apiserver
+
+import (
+	"github.com/fission/fission-workflows/pkg/types/validate"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func toErrorStatus(err error) error {
+	switch err.(type) {
+	case validate.Error:
+		logrus.Errorf("Request error: %v", validate.FormatConcise(err))
+		return status.Error(codes.InvalidArgument, validate.Format(err))
+	default:
+		logrus.Errorf("Request error: %v", err)
+		return err
+	}
+}

--- a/pkg/apiserver/workflow.go
+++ b/pkg/apiserver/workflow.go
@@ -1,20 +1,16 @@
 package apiserver
 
 import (
-	"errors"
-	"strings"
-
 	"github.com/fission/fission-workflows/pkg/api"
 	"github.com/fission/fission-workflows/pkg/fes"
 	"github.com/fission/fission-workflows/pkg/types"
 	"github.com/fission/fission-workflows/pkg/types/aggregates"
 	"github.com/fission/fission-workflows/pkg/types/validate"
 	"github.com/golang/protobuf/ptypes/empty"
-	"github.com/sirupsen/logrus"
-
 	"golang.org/x/net/context"
 )
 
+// Workflow is responsible for all functionality related to managing workflows.
 type Workflow struct {
 	api   *api.Workflow
 	cache fes.CacheReader
@@ -30,39 +26,27 @@ func NewWorkflow(api *api.Workflow, cache fes.CacheReader) *Workflow {
 }
 
 func (ga *Workflow) Create(ctx context.Context, spec *types.WorkflowSpec) (*WorkflowIdentifier, error) {
-
 	id, err := ga.api.Create(spec)
 	if err != nil {
-		logrus.Info(strings.Replace(validate.Format(err), "\n", "; ", -1))
-		return nil, err
+		return nil, toErrorStatus(err)
 	}
 
 	return &WorkflowIdentifier{id}, nil
 }
 
 func (ga *Workflow) Get(ctx context.Context, workflowID *WorkflowIdentifier) (*types.Workflow, error) {
-	id := workflowID.GetId()
-	if len(id) == 0 {
-		return nil, errors.New("no id provided")
-	}
-
-	entity := aggregates.NewWorkflow(id)
+	entity := aggregates.NewWorkflow(workflowID.GetId())
 	err := ga.cache.Get(entity)
 	if err != nil {
-		return nil, err
+		return nil, toErrorStatus(err)
 	}
 	return entity.Workflow, nil
 }
 
 func (ga *Workflow) Delete(ctx context.Context, workflowID *WorkflowIdentifier) (*empty.Empty, error) {
-	id := workflowID.GetId()
-	if len(id) == 0 {
-		return nil, errors.New("no id provided")
-	}
-
-	err := ga.api.Delete(id)
+	err := ga.api.Delete(workflowID.GetId())
 	if err != nil {
-		return nil, err
+		return nil, toErrorStatus(err)
 	}
 	return &empty.Empty{}, nil
 }
@@ -79,8 +63,7 @@ func (ga *Workflow) List(ctx context.Context, req *empty.Empty) (*SearchWorkflow
 func (ga *Workflow) Validate(ctx context.Context, spec *types.WorkflowSpec) (*empty.Empty, error) {
 	err := validate.WorkflowSpec(spec)
 	if err != nil {
-		logrus.Info(strings.Replace(validate.Format(err), "\n", "; ", -1))
-		return nil, err
+		return nil, toErrorStatus(err)
 	}
 	return &empty.Empty{}, nil
 }

--- a/pkg/types/typedvalues/controlflow.go
+++ b/pkg/types/typedvalues/controlflow.go
@@ -131,10 +131,30 @@ func ParseControlFlow(i interface{}) (*types.TypedValue, error) {
 	}
 }
 
+type FlowType string
+
+const (
+	Workflow FlowType = "workflow"
+	Task     FlowType = "task"
+	None     FlowType = ""
+)
+
 // Flow is a generic data type to provide a common API to working with dynamic tasks and workflows
+// If a flow contains both a task and a workflow, behavior is non-standard,
+// but should in principle default to the task.
 type Flow struct {
 	task *types.TaskSpec
 	wf   *types.WorkflowSpec
+}
+
+func (f *Flow) Type() FlowType {
+	if f.task != nil {
+		return Task
+	}
+	if f.wf != nil {
+		return Workflow
+	}
+	return None
 }
 
 func (f *Flow) Input(key string, i types.TypedValue) {


### PR DESCRIPTION
To ensure that HTTP response statuses better fit the actual error, this PR converts errors explicitely to gRPC status errors. This ensures that validation errors get converted to 402s, instead of 500s.