### PR TITLE
Cleanup labels package

### DIFF
--- a/cmd/fission-workflows-bundle/bundle/bundle.go
+++ b/cmd/fission-workflows-bundle/bundle/bundle.go
@@ -290,7 +290,7 @@ func setupNatsEventStoreClient(url string, cluster string, clientID string) *nat
 func setupWorkflowInvocationCache(ctx context.Context, invocationEventPub pubsub.Publisher) *fes.SubscribedCache {
 	invokeSub := invocationEventPub.Subscribe(pubsub.SubscriptionOptions{
 		Buffer: 50,
-		Selector: labels.Or(
+		LabelMatcher: labels.Or(
 			labels.In(fes.PubSubLabelAggregateType, "invocation"),
 			labels.In("parent.type", "invocation")),
 	})
@@ -303,8 +303,8 @@ func setupWorkflowInvocationCache(ctx context.Context, invocationEventPub pubsub
 
 func setupWorkflowCache(ctx context.Context, workflowEventPub pubsub.Publisher) *fes.SubscribedCache {
 	wfSub := workflowEventPub.Subscribe(pubsub.SubscriptionOptions{
-		Buffer:   10,
-		Selector: labels.In(fes.PubSubLabelAggregateType, "workflow"),
+		Buffer:       10,
+		LabelMatcher: labels.In(fes.PubSubLabelAggregateType, "workflow"),
 	})
 	wb := func() fes.Aggregator {
 		return aggregates.NewWorkflow("")

--- a/pkg/controller/invocation/controller.go
+++ b/pkg/controller/invocation/controller.go
@@ -101,8 +101,8 @@ func (cr *Controller) Init(sctx context.Context) error {
 	selector := labels.In(fes.PubSubLabelAggregateType, "invocation", "function")
 	if invokePub, ok := cr.invokeCache.(pubsub.Publisher); ok {
 		cr.sub = invokePub.Subscribe(pubsub.SubscriptionOptions{
-			Buffer:   NotificationBuffer,
-			Selector: selector,
+			Buffer:       NotificationBuffer,
+			LabelMatcher: selector,
 		})
 
 		// Invocation Notification listener

--- a/pkg/controller/workflow/controller.go
+++ b/pkg/controller/workflow/controller.go
@@ -79,8 +79,8 @@ func (c *Controller) Init(sctx context.Context) error {
 	selector := labels.In(fes.PubSubLabelAggregateType, "workflow")
 	if invokePub, ok := c.wfCache.(pubsub.Publisher); ok {
 		c.sub = invokePub.Subscribe(pubsub.SubscriptionOptions{
-			Buffer:   NotificationBuffer,
-			Selector: selector,
+			Buffer:       NotificationBuffer,
+			LabelMatcher: selector,
 		})
 
 		// Workflow Notification listener

--- a/pkg/fes/backend/mem/mem_test.go
+++ b/pkg/fes/backend/mem/mem_test.go
@@ -69,7 +69,7 @@ func TestBackend_Subscribe(t *testing.T) {
 	mem := NewBackend()
 	key := fes.NewAggregate("type", "id")
 	sub := mem.Subscribe(pubsub.SubscriptionOptions{
-		Selector: labels.In(fes.PubSubLabelAggregateType, key.Type),
+		LabelMatcher: labels.In(fes.PubSubLabelAggregateType, key.Type),
 	})
 
 	events := []*fes.Event{

--- a/pkg/fes/proto.go
+++ b/pkg/fes/proto.go
@@ -26,7 +26,7 @@ func (m *Event) Labels() labels.Labels {
 
 	// TODO could be created using reflection
 	// TODO cache somewhere to avoid rebuilding on every request
-	return labels.SetLabels{
+	return labels.Set{
 		"aggregate.id":   m.Aggregate.Id,
 		"aggregate.type": m.Aggregate.Type,
 		"parent.type":    parent.Type,

--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -1,46 +1,64 @@
+// Package labels provides storing, fetching and matching based on labels.
 package labels
 
+// Labels is the interface for fetching labels.
 type Labels interface {
-	// Has returns whether the provided label exists.
-	Has(label string) (exists bool)
-
 	// Get returns the value for the provided label.
-	Get(label string) (value string)
+	Get(label string) (value string, exists bool)
 }
 
-type Selector interface {
+// Matcher is the interface for matching objects based on their labels.
+type Matcher interface {
 	Matches(labels Labels) bool
 }
 
-type SetLabels map[string]string
+// Set is a set of labels, in which a key can only occur once.
+type Set map[string]string
 
-func (l SetLabels) Has(label string) (exists bool) {
-	_, ok := l[label]
-	return ok
+// Get fetches a label based on the key. If the label exists the value will be returned.
+//
+// If the set is nil, Get will simply return that the label does not exist either.
+func (l Set) Get(label string) (value string, exists bool) {
+	if l == nil {
+		return "", false
+	}
+	value, exists = l[label]
+	return value, exists
 }
 
-func (l SetLabels) Get(label string) (value string) {
-	return l[label]
+// Set stores a label with the associated value.
+//
+// If the set is nil, a set will be created.
+// If a label with the same name exists already in the set, it will be overwritten.
+func (l *Set) Set(label, value string) {
+	if l == nil {
+		*l = map[string]string{}
+	}
+	(*l)[label] = value
 }
 
-type InSelector struct {
+// InMatcher matches all labels where the label keys equals the key, and (optionally)
+// the value has to be in the set of accepted values.
+type InMatcher struct {
 	Key    string
 	Values []string
 }
 
-func In(key string, values ...string) *InSelector {
-	return &InSelector{
+// In matches all labels where the label keys equals the key, and (optionally)
+// the value has to be in the set of accepted values.
+func In(key string, values ...string) InMatcher {
+	return InMatcher{
 		Key:    key,
 		Values: values,
 	}
 }
 
-func (s *InSelector) Matches(labels Labels) bool {
-	if !labels.Has(s.Key) {
+// Matches returns true if the labels are selected by one of the matchers in the inMatches.
+func (s InMatcher) Matches(labels Labels) bool {
+	val, ok := labels.Get(s.Key)
+	if !ok {
 		return false
 	}
-
-	val := labels.Get(s.Key)
 	for _, v := range s.Values {
 		if val == v {
 			return true
@@ -50,40 +68,42 @@ func (s *InSelector) Matches(labels Labels) bool {
 	return false
 }
 
-type AndSelector struct {
-	Selectors []Selector
+// AndMatcher is a composite matcher that selects all labels that are selected by all matchers.
+type AndMatcher struct {
+	Matchers []Matcher
 }
 
-func And(reqs ...Selector) *AndSelector {
-	return &AndSelector{reqs}
+// And returns a composite matcher that selects all labels that are selected by all matchers.
+func And(ms ...Matcher) AndMatcher {
+	return AndMatcher{ms}
 }
 
-func (s *AndSelector) Matches(labels Labels) bool {
-	for _, req := range s.Selectors {
-		valid := req.Matches(labels)
-		if !valid {
+// Matches returns true if the labels are selected by one of the matchers in the andMatchers.
+func (s AndMatcher) Matches(labels Labels) bool {
+	for _, req := range s.Matchers {
+		if !req.Matches(labels) {
 			return false
 		}
 	}
-
 	return true
 }
 
-type OrSelector struct {
-	Selectors []Selector
+// OrMatcher is a composite matcher that selects all labels that are selected by one of the matchers.
+type OrMatcher struct {
+	matchers []Matcher
 }
 
-func Or(reqs ...Selector) *OrSelector {
-	return &OrSelector{reqs}
+// Or returns a composite matcher that selects all labels that are selected by one of the matchers.
+func Or(ms ...Matcher) OrMatcher {
+	return OrMatcher{ms}
 }
 
-func (s *OrSelector) Matches(labels Labels) bool {
-	for _, req := range s.Selectors {
-		valid := req.Matches(labels)
-		if valid {
+// Matches returns true if the labels are selected by one of the matchers in the orMatchers.
+func (s OrMatcher) Matches(labels Labels) bool {
+	for _, req := range s.matchers {
+		if req.Matches(labels) {
 			return true
 		}
 	}
-
 	return false
 }

--- a/pkg/util/pubsub/pubsub.go
+++ b/pkg/util/pubsub/pubsub.go
@@ -25,14 +25,15 @@ type Publisher interface {
 	Publish(msg Msg) error
 }
 
+// SubscriptionOptions allow subscribers to customize the type and behaviour of the subscription.
 type SubscriptionOptions struct {
 	// Buffer is the size of the buffer kept for incoming messages. In case the buffer is full, subsequent messages will
 	// be dropped. The default size of the buffer is 10.
 	Buffer int
 
-	// Selector allows subscribers to narrow the selection of messages that they are notified of. By default there is no
-	// selector; the subscriber will receive all messages published by the publisher.
-	Selector labels.Selector
+	// LabelMatcher allows subscribers to narrow the selection of messages that they are notified of.
+	// By default there is no matcher; the subscriber will receive all messages published by the publisher.
+	LabelMatcher labels.Matcher
 }
 
 type Subscription struct {
@@ -125,7 +126,7 @@ func (pu *DefaultPublisher) Publish(msg Msg) error {
 	pu.lock.Lock()
 	defer pu.lock.Unlock()
 	for _, sub := range pu.subs {
-		if sub.Selector != nil && !sub.Selector.Matches(msg.Labels()) {
+		if sub.LabelMatcher != nil && !sub.LabelMatcher.Matches(msg.Labels()) {
 			continue
 		}
 		select {

--- a/pkg/util/pubsub/pubsub_test.go
+++ b/pkg/util/pubsub/pubsub_test.go
@@ -24,7 +24,7 @@ func TestPublish(t *testing.T) {
 		Buffer: 1,
 	})
 
-	msg := NewGenericMsg(labels.SetLabels{"foo": "bar"}, time.Now(), "TestMsg")
+	msg := NewGenericMsg(labels.Set{"foo": "bar"}, time.Now(), "TestMsg")
 
 	err := pub.Publish(msg)
 	assert.NoError(t, err)
@@ -43,8 +43,8 @@ func TestPublishBufferOverflow(t *testing.T) {
 		Buffer: 10,
 	})
 
-	firstMsg := NewGenericMsg(labels.SetLabels(map[string]string{"foo": "bar"}), time.Now(), "TestMsg1")
-	secondMsg := NewGenericMsg(labels.SetLabels(map[string]string{"foo": "bar"}), time.Now(), "TestMsg2")
+	firstMsg := NewGenericMsg(labels.Set(map[string]string{"foo": "bar"}), time.Now(), "TestMsg1")
+	secondMsg := NewGenericMsg(labels.Set(map[string]string{"foo": "bar"}), time.Now(), "TestMsg2")
 
 	err := pub.Publish(firstMsg)
 	assert.NoError(t, err)


### PR DESCRIPTION
As part of a cleanup of stale, but as-good-as-finished, PRs - this PR cleans up the labels package. It renames some of the functions and structs in package to better fitting names and adds documentation throughout.  Additionally it removes the need for our custom struct-to-map functions by using the `structs` package.