### PR TITLE
Set content-length when setting body

### DIFF
--- a/pkg/fnenv/common/httpconv/httpconv.go
+++ b/pkg/fnenv/common/httpconv/httpconv.go
@@ -27,7 +27,7 @@ const (
 	contentTypeWorkflow = "application/vnd.fission.workflows.task"     // Default format: protobuf, +json for json
 	contentTypeProtobuf = "application/protobuf"                       // Default format: protobuf, +json for json
 	contentTypeDefault  = contentTypeText
-	methodDefault       = http.MethodGet
+	methodDefault       = http.MethodPost
 )
 
 // ParseRequest maps a HTTP request to a target map.
@@ -182,6 +182,7 @@ func FormatRequest(source map[string]*types.TypedValue, target *http.Request) er
 			return err
 		}
 		target.Body = ioutil.NopCloser(bytes.NewReader(bs))
+		target.ContentLength = int64(len(bs))
 	}
 
 	// Map method input to HTTP method


### PR DESCRIPTION
The `Content-Length` header in Golang `http` requests is [only set when using `NewRequest`](https://github.com/golang/go/blob/fced03a5c6dd22dd486106e3dd116510c28c6e4a/src/net/http/request.go#L565-L574) (instead of being set when the actual request is send). This means that when setting the Body field after the initial construction of the request, the content-length will remain unset unless explicitly set by the user.

To fix this issue, this PR explicitly sets the contentLength when setting the body.

As a flyby this PR also changes the default method to be used for fission requests to `post`, as this used to be (and still should be) the default. 

cc @soamvasani