### PR TITLE
add NOBUILD ARG to script

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /go/src/github.com/fission/fission-workflows
 
 COPY . .
 
-RUN if [ "_$NOBUILD" = "_" ] ; then \
+RUN if ! $NOBUILD ; then \
         go get github.com/Masterminds/glide; \
         glide install -v; \
         build/build-linux.sh; \

--- a/build/docker.sh
+++ b/build/docker.sh
@@ -8,11 +8,12 @@ set -eo pipefail
 BUILD_ROOT=$(dirname $0)
 IMAGE_REPO=${1:-fission}
 IMAGE_TAG=${2:-latest}
+NOBUILD=${3:-false}
 
 # Build bundle images
 bundleImage=${IMAGE_REPO}/fission-workflows-bundle
 pushd ${BUILD_ROOT}/..
-if [ ! -z "$NOBUILD" ]; then
+if $NOBUILD ; then
     if [ ! -f ./fission-workflows-bundle ]; then
         echo "Executable './fission-workflows-bundle' not found!"
         exit 1;


### PR DESCRIPTION
This add a input flag `NOBUILD` to  `build/docker.sh`, to allow users to build the bundle out of docker build stage.