### PR TITLE
remove the infinite loop log messages

### DIFF
--- a/pkg/controller/invocation/controller.go
+++ b/pkg/controller/invocation/controller.go
@@ -266,7 +266,6 @@ func (cr *Controller) Evaluate(invocationID string) {
 		controller.EvalJobs.WithLabelValues(Name, "duplicate").Inc()
 		return
 	}
-	log.Debugf("evaluating invocation %s", invocationID)
 
 	// Fetch the workflow invocation for the provided invocation id
 	wfi := aggregates.NewWorkflowInvocation(invocationID)
@@ -279,7 +278,6 @@ func (cr *Controller) Evaluate(invocationID string) {
 	}
 	// TODO move to rule
 	if wfi.Status.Finished() {
-		wfiLog.Debugf("No need to evaluate finished invocation %v", invocationID)
 		controller.EvalJobs.WithLabelValues(Name, "error").Inc()
 		return
 	}

--- a/pkg/controller/invocation/rules.go
+++ b/pkg/controller/invocation/rules.go
@@ -64,7 +64,6 @@ func (wr *RuleWorkflowIsReady) Eval(cec controller.EvalContext) controller.Actio
 	wf := ec.Workflow()
 	// Check if workflow is in the right state to use.
 	if !wf.Status.Ready() {
-		log.WithField("wf.status", wf.Status.Status).Error("Workflow is not ready yet.")
 		return &controller.ActionSkip{} // TODO backoff action
 	}
 	return nil


### PR DESCRIPTION
The infinite loop logs seem to bring few useful information, and flush
log console rapidly.

Here remove them simply. In future we might should improve the mechanism
of inovation eval.