### PR TITLE
Fix HTTP handler of health checking

### DIFF
--- a/pkg/fnenv/fission/envproxy.go
+++ b/pkg/fnenv/fission/envproxy.go
@@ -44,7 +44,7 @@ func NewFissionProxyServer(wfiSrv apiserver.WorkflowInvocationAPIServer, wfSrv a
 func (fp *Proxy) RegisterServer(mux *http.ServeMux) {
 	mux.HandleFunc("/", fp.handleRequest)
 	mux.HandleFunc("/v2/specialize", fp.handleSpecialize)
-	mux.HandleFunc("/healthz", fp.handleSpecialize)
+	mux.HandleFunc("/healthz", fp.handleHealthCheck)
 }
 
 func (fp *Proxy) handleHealthCheck(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
HTTP handler of health checking seems to be configured `handleSpecialize` incorrectly. 