### PR TITLE
Add support for jsonpb-encoded workflow specs

### DIFF
--- a/pkg/parse/protobuf/parser_test.go
+++ b/pkg/parse/protobuf/parser_test.go
@@ -1,0 +1,71 @@
+package protobuf
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/fission/fission-workflows/pkg/types"
+	"github.com/fission/fission-workflows/pkg/types/typedvalues"
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseProto(t *testing.T) {
+	originalWfSpec := &types.WorkflowSpec{
+		ApiVersion: types.WorkflowAPIVersion,
+		OutputTask: "fakeFinalTask",
+		Tasks: map[string]*types.TaskSpec{
+			"fakeFinalTask": {
+				FunctionRef: "noop",
+				Inputs: map[string]*types.TypedValue{
+					types.InputMain: typedvalues.MustParse("{$.Tasks.FirstTask.Output}"),
+				},
+				Requires: map[string]*types.TaskDependencyParameters{
+					"FirstTask": {},
+				},
+			},
+			"FirstTask": {
+				FunctionRef: "noop",
+				Inputs: map[string]*types.TypedValue{
+					types.InputMain: typedvalues.MustParse("{$.Invocation.Inputs.default.toUpperCase()}"),
+				},
+			},
+		},
+	}
+	msg, err := proto.Marshal(originalWfSpec)
+	assert.NoError(t, err)
+	parsedWfSpec, err := Parse(bytes.NewReader(msg))
+	assert.NoError(t, err)
+	assert.Equal(t, originalWfSpec, parsedWfSpec)
+}
+
+func TestParseJson(t *testing.T) {
+	originalWfSpec := &types.WorkflowSpec{
+		ApiVersion: types.WorkflowAPIVersion,
+		OutputTask: "fakeFinalTask",
+		Tasks: map[string]*types.TaskSpec{
+			"fakeFinalTask": {
+				FunctionRef: "noop",
+				Inputs: map[string]*types.TypedValue{
+					types.InputMain: typedvalues.MustParse("{$.Tasks.FirstTask.Output}"),
+				},
+				Requires: map[string]*types.TaskDependencyParameters{
+					"FirstTask": {},
+				},
+			},
+			"FirstTask": {
+				FunctionRef: "noop",
+				Inputs: map[string]*types.TypedValue{
+					types.InputMain: typedvalues.MustParse("{$.Invocation.Inputs.default.toUpperCase()}"),
+				},
+			},
+		},
+	}
+	msg, err := (&jsonpb.Marshaler{}).MarshalToString(originalWfSpec)
+	assert.NoError(t, err)
+	parsedWfSpec, err := Parse(strings.NewReader(msg))
+	assert.NoError(t, err)
+	assert.Equal(t, originalWfSpec, parsedWfSpec)
+}


### PR DESCRIPTION
This PR adds support for JSON-encoded protobuf workflow definitions, which is needed for a workflow generation tool that I am working on.