### PR TITLE
Constrain memory usage in the in-memory backend

### DIFF
--- a/cmd/fission-workflows-bundle/bundle/bundle.go
+++ b/cmd/fission-workflows-bundle/bundle/bundle.go
@@ -314,7 +314,7 @@ func run(ctx context.Context, opts *Options) error {
 		}()
 		defer func() {
 			err := httpApiSrv.Shutdown(ctx)
-			log.Info("Stopped HTTP API server: %v", err)
+			log.Infof("Stopped HTTP API server: %v", err)
 		}()
 
 		log.Info("Serving HTTP API gateway at: ", httpApiSrv.Addr)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 6903c5d9f84153e543483015f749a22afd7ca331b979a124c825ed977a4026d3
-updated: 2018-09-03T16:53:54.242728+02:00
+hash: 8625631121e3da0aa6118e13145d87b9efb1659cb820d24b2c2f781af212556a
+updated: 2018-09-20T14:16:47.976902+02:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -68,6 +68,10 @@ imports:
   - types
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
+- name: github.com/golang/groupcache
+  version: 24b0969c4cb722950103eed87108c8d291a8df00
+  subpackages:
+  - lru
 - name: github.com/golang/protobuf
   version: aa810b61a9c79d51363740d207bb46cf8e620ed5
   subpackages:
@@ -128,7 +132,7 @@ imports:
 - name: github.com/hashicorp/go-multierror
   version: 3d5d8f294aa03d8e98859feac328afbdf1ae0703
 - name: github.com/hashicorp/golang-lru
-  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  version: 20f1fb78b0740ba8c3cb143a61e86ba5c8669768
   subpackages:
   - simplelru
 - name: github.com/howeyc/gopass
@@ -155,7 +159,7 @@ imports:
   subpackages:
   - pb
 - name: github.com/nats-io/nats-streaming-server
-  version: 63e2c334b66dba3edade0047625a25c0d8f18f80
+  version: 8910c0c347bc51cc87227aeb27bef19d409bf5c2
   subpackages:
   - spb
   - util

--- a/glide.yaml
+++ b/glide.yaml
@@ -76,6 +76,8 @@ import:
 - package: github.com/grpc-ecosystem/grpc-opentracing
   subpackages:
   - go/otgrpc
+- package: github.com/hashicorp/golang-lru
+  version: v0.5.0
 testImport:
 - package: github.com/stretchr/testify
   version: 1.1.4

--- a/pkg/apiserver/httpclient/httpclient.go
+++ b/pkg/apiserver/httpclient/httpclient.go
@@ -56,7 +56,7 @@ func callWithJSON(ctx context.Context, method string, url string, in proto.Messa
 			if err != nil {
 				logrus.Errorf("Failed to read debug data: %v", err)
 			}
-			logrus.Debug("body: '%v'", data)
+			logrus.Debugf("body: '%v'", data)
 		}
 	}
 	req, err := http.NewRequest(method, url, buf)

--- a/pkg/apiserver/invocation.go
+++ b/pkg/apiserver/invocation.go
@@ -81,7 +81,7 @@ func (gi *Invocation) List(ctx context.Context, query *InvocationListQuery) (*Wo
 			// TODO make more efficient (by moving list queries to cache)
 			entity, err := gi.wfiCache.GetAggregate(aggregate)
 			if err != nil {
-				logrus.Error("List: failed to fetch %v from cache: %v", aggregate, err)
+				logrus.Errorf("List: failed to fetch %v from cache: %v", aggregate, err)
 				continue
 			}
 			wfi := entity.(*aggregates.WorkflowInvocation)

--- a/pkg/fes/backend/nats/client.go
+++ b/pkg/fes/backend/nats/client.go
@@ -169,8 +169,8 @@ func (es *EventStore) Append(event *fes.Event) error {
 
 // Get returns all events related to a specific aggregate
 func (es *EventStore) Get(aggregate fes.Aggregate) ([]*fes.Event, error) {
-	if !fes.ValidateAggregate(&aggregate) {
-		return nil, ErrInvalidAggregate
+	if err := fes.ValidateAggregate(&aggregate); err != nil {
+		return nil, err
 	}
 	subject := toSubject(aggregate)
 

--- a/pkg/fes/entity.go
+++ b/pkg/fes/entity.go
@@ -60,6 +60,9 @@ func NewBaseEntity(thiz Entity, aggregate Aggregate) *BaseEntity {
 	}
 }
 
-func ValidateAggregate(a *Aggregate) bool {
-	return a != nil && len(a.Type) != 0 && len(a.Id) != 0
+func ValidateAggregate(a *Aggregate) error {
+	if a != nil && len(a.Type) != 0 && len(a.Id) != 0 {
+		return nil
+	}
+	return ErrInvalidAggregate.WithAggregate(a)
 }

--- a/pkg/fes/types.go
+++ b/pkg/fes/types.go
@@ -1,6 +1,8 @@
 package fes
 
 import (
+	"fmt"
+
 	"github.com/fission/fission-workflows/pkg/util/pubsub"
 	"github.com/opentracing/opentracing-go"
 	"github.com/sirupsen/logrus"
@@ -85,3 +87,26 @@ func newNotification(entity Entity, event *Event) *Notification {
 		SpanCtx:   spanCtx,
 	}
 }
+
+type EventStoreErr struct {
+	S string
+	K *Aggregate
+}
+
+func (err *EventStoreErr) WithAggregate(aggregate *Aggregate) *EventStoreErr {
+	err.K = aggregate
+	return err
+}
+
+func (err *EventStoreErr) Error() string {
+	if err.K == nil {
+		return err.S
+	} else {
+		return fmt.Sprintf("%v: %s", err.K.Format(), err.S)
+	}
+}
+
+var (
+	ErrInvalidAggregate   = &EventStoreErr{S: "invalid aggregate"}
+	ErrEventStoreOverflow = &EventStoreErr{S: "event store out of space"}
+)

--- a/pkg/fnenv/fission/runtime.go
+++ b/pkg/fnenv/fission/runtime.go
@@ -108,7 +108,7 @@ func (fe *FunctionEnv) Invoke(spec *types.TaskInvocationSpec, opts ...fnenv.Invo
 	// Determine status of the task invocation
 	if resp.StatusCode >= 400 {
 		msg, _ := typedvalues.Format(&output)
-		ctxLog.Warnf("[%s] Failed %v: %v", resp.StatusCode, msg)
+		ctxLog.Warnf("[%s] Failed %v: %v", fnRef.ID, resp.StatusCode, msg)
 		return &types.TaskInvocationStatus{
 			Status: types.TaskInvocationStatus_FAILED,
 			Error: &types.Error{

--- a/pkg/fnenv/native/builtin/if.go
+++ b/pkg/fnenv/native/builtin/if.go
@@ -77,7 +77,7 @@ func (fn *FunctionIf) Invoke(spec *types.TaskInvocationSpec) (*types.TypedValue,
 	}
 
 	// Output consequent or alternative based on condition
-	logrus.Infof("If-task has evaluated to '%b''", condition)
+	logrus.Infof("If-task has evaluated to '%v''", condition)
 	if condition {
 		return consequent, nil
 	}

--- a/pkg/fnenv/native/builtin/switch.go
+++ b/pkg/fnenv/native/builtin/switch.go
@@ -98,7 +98,6 @@ func (fn *FunctionSwitch) getCases(inputs map[string]*types.TypedValue) (map[str
 		for _, c := range ir {
 			m, ok := c.(map[string]interface{})
 			if !ok {
-				logrus.Warnf("Invalid case provided: %t", m)
 				return nil, nil, errors.New("invalid case provided")
 			}
 			tva, err := typedvalues.Parse(m[SwitchCaseValue])

--- a/pkg/types/typedvalues/httpconv/httpconv.go
+++ b/pkg/types/typedvalues/httpconv/httpconv.go
@@ -235,7 +235,7 @@ func FormatMethod(inputs map[string]*types.TypedValue) string {
 		if err == nil {
 			return contentType
 		}
-		logrus.Error("Invalid method in inputs: %+v", tv)
+		logrus.Errorf("Invalid method in inputs: %+v", tv)
 	}
 	return methodDefault
 }
@@ -354,7 +354,7 @@ func DetermineContentTypeInputs(inputs map[string]*types.TypedValue) string {
 		if err == nil {
 			return contentType
 		}
-		logrus.Error("Invalid content type in inputs: %+v", ctTv)
+		logrus.Errorf("Invalid content type in inputs: %+v", ctTv)
 	}
 
 	// Otherwise, check for label on body input

--- a/pkg/types/typedvalues/typedvalues.go
+++ b/pkg/types/typedvalues/typedvalues.go
@@ -92,7 +92,6 @@ func (pf *ComposedParserFormatter) Parse(ctx Parser, i interface{}) (*types.Type
 				return nil, err
 			}
 		}
-		logrus.Debugf("Parser success: %t", tv)
 		return tv, nil
 	}
 	logrus.Debugf("No parsers for %t", i)

--- a/test/integration/nats/nats_test.go
+++ b/test/integration/nats/nats_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	backend fes.Backend
+	backend *nats.EventStore
 )
 
 // Tests the event store implementation with a live NATS cluster.
@@ -66,6 +66,16 @@ func TestMain(m *testing.M) {
 		if err != nil {
 			return fmt.Errorf("failed to connect to cluster: %v", err)
 		}
+
+		err = backend.Watch(fes.Aggregate{Type: "invocation"})
+		if err != nil {
+			panic(err)
+		}
+		err = backend.Watch(fes.Aggregate{Type: "workflow"})
+		if err != nil {
+			panic(err)
+		}
+
 		return nil
 	}); err != nil {
 		log.Fatalf("Could not connect to docker: %s", err)


### PR DESCRIPTION
Currently, originally intended for simple development and testing, this backend consisted solely out of a map containing all events. As it would never remove old/completed invocations/workflows this meant that over time the event store would hog up more and more memory until an inevitable OOM occurred.

This PR has as a goal to make the in-memory event store feasible for longer-term or more intensive deployments, such as benchmarks and use cases that don't require persistence of events. The solution in this PR is to use an approach akin to TinyLFU for caches. The store is assigned specific limits to the number of entities (`n`) it contains, which are contained in two segments:
- **store** which contains all currently active event streams, which under no circumstance should be deleted.
- **buffer** which is a LRU cache contains all completed event streams (event streams that have a last event with the `completed` flag). The size of the buffer is dynamic; it fills all available space between the store and `n`, evicting entities if the space is exceeded.

Concretely, this PR...
- Adds benchmarks for the in-memory store.
- Adds a LRU cache to the in-memory backend as a buffer for completed invocations. 
- Adds a couple of metrics to the in-memory store.
- Adds configuration options to the in-memory store, allowing users to specify limits on the resource usage.
- Introduces an EventStoreErr to the event store package, that should serve as the base error for the package eventually.
- Fixes a couple of logrus incorrect log statements, which will error in newer logrus versions otherwise.

