### PR TITLE
Added invocation and workflow stores for typed entity retrieval

### DIFF
--- a/pkg/api/store/store.go
+++ b/pkg/api/store/store.go
@@ -1,0 +1,177 @@
+// package store provides typed, centralized access to the event-sourced workflow and invocation models
+package store
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/fission/fission-workflows/pkg/api/aggregates"
+	"github.com/fission/fission-workflows/pkg/fes"
+	"github.com/fission/fission-workflows/pkg/types"
+	"github.com/fission/fission-workflows/pkg/util/labels"
+	"github.com/fission/fission-workflows/pkg/util/pubsub"
+)
+
+type Workflows struct {
+	fes.CacheReader // Currently needed for pubsub publisher interface, should be exposed here
+}
+
+func NewWorkflowsStore(workflows fes.CacheReader) *Workflows {
+	return &Workflows{
+		workflows,
+	}
+}
+
+// GetWorkflow returns an event-sourced workflow.
+// If an error occurred the error is returned, if no workflow was found both return values are nil.
+func (s *Workflows) GetWorkflow(workflowID string) (*types.Workflow, error) {
+	key := fes.NewAggregate(aggregates.TypeWorkflow, workflowID)
+	entity, err := s.GetAggregate(key)
+	if err != nil {
+		return nil, err
+	}
+	if entity == nil {
+		return nil, nil
+	}
+
+	wf, ok := entity.(*aggregates.Workflow)
+	if !ok {
+		panic(fmt.Sprintf("aggregate type mismatch for key %s (expected: %T, got %T)", key.Format(),
+			&aggregates.Workflow{}, wf))
+	}
+
+	return wf.Workflow, nil
+}
+
+// GetWorkflowNotifications returns a subscription to the updates of the workflow cache.
+// Returns nil if the cache does not support pubsub.
+//
+// Future: Currently this assumes the presence of a pubsub.Publisher interface in the cache.
+// In the future we can fallback to pull-based mechanisms
+func (s *Workflows) GetWorkflowUpdates() *WorkflowSubscription {
+	selector := labels.In(fes.PubSubLabelAggregateType, aggregates.TypeWorkflow)
+	invokePub, ok := s.CacheReader.(pubsub.Publisher)
+	if !ok {
+		return nil
+	}
+
+	return &WorkflowSubscription{
+		Subscription: invokePub.Subscribe(pubsub.SubscriptionOptions{
+			Buffer:       fes.DefaultNotificationBuffer,
+			LabelMatcher: selector,
+		}),
+		closeFn: func() error {
+			return invokePub.Close()
+		},
+	}
+}
+
+type Invocations struct {
+	fes.CacheReader
+}
+
+func NewInvocationStore(invocations fes.CacheReader) *Invocations {
+	return &Invocations{
+		invocations,
+	}
+}
+
+// GetInvocation returns an event-sourced invocation.
+// If an error occurred the error is returned, if no invocation was found both return values are nil.
+func (s *Invocations) GetInvocation(invocationID string) (*types.WorkflowInvocation, error) {
+	key := fes.NewAggregate(aggregates.TypeWorkflowInvocation, invocationID)
+	entity, err := s.GetAggregate(key)
+	if err != nil {
+		return nil, err
+	}
+	if entity == nil {
+		return nil, nil
+	}
+
+	wfi, ok := entity.(*aggregates.WorkflowInvocation)
+	if !ok {
+		panic(fmt.Sprintf("aggregate type mismatch for key %s (expected: %T, got %T - %v)", key.Format(),
+			&aggregates.WorkflowInvocation{}, wfi, wfi))
+	}
+
+	return wfi.WorkflowInvocation, nil
+}
+
+// GetInvocationSubscription returns a subscription to the updates of the invocation cache.
+// Returns nil if the cache does not support pubsub.
+//
+// Future: Currently this assumes the presence of a pubsub.Publisher interface in the cache.
+// In the future we can fallback to pull-based mechanisms
+func (s *Invocations) GetInvocationUpdates() *InvocationSubscription {
+	selector := labels.In(fes.PubSubLabelAggregateType, aggregates.TypeWorkflowInvocation, aggregates.TypeTaskInvocation)
+	invokePub, ok := s.CacheReader.(pubsub.Publisher)
+	if !ok {
+		return nil
+	}
+
+	return &InvocationSubscription{
+		Subscription: invokePub.Subscribe(pubsub.SubscriptionOptions{
+			Buffer:       fes.DefaultNotificationBuffer,
+			LabelMatcher: selector,
+		}),
+		closeFn: func() error {
+			return invokePub.Close()
+		},
+	}
+}
+
+type WorkflowSubscription struct {
+	*pubsub.Subscription
+	closeFn func() error
+}
+
+func (sub *WorkflowSubscription) ToNotification(msg pubsub.Msg) (*fes.Notification, error) {
+	update, ok := msg.(*fes.Notification)
+	if !ok {
+		return nil, errors.New("received message is not a notification")
+	}
+	return update, nil
+}
+
+func (sub *WorkflowSubscription) Close() error {
+	if sub.closeFn == nil {
+		return nil
+	}
+	return sub.closeFn()
+}
+
+type InvocationSubscription struct {
+	*pubsub.Subscription
+	closeFn func() error
+}
+
+func (sub *InvocationSubscription) ToNotification(msg pubsub.Msg) (*fes.Notification, error) {
+	update, ok := msg.(*fes.Notification)
+	if !ok {
+		return nil, errors.New("received message is not a notification")
+	}
+	return update, nil
+}
+
+func (sub *InvocationSubscription) Close() error {
+	if sub.closeFn == nil {
+		return nil
+	}
+	return sub.closeFn()
+}
+
+func ParseNotificationToWorkflow(update *fes.Notification) (*types.Workflow, error) {
+	entity, ok := update.Payload.(*aggregates.Workflow)
+	if !ok {
+		return nil, errors.New("received message does not include workflow invocation as payload")
+	}
+	return entity.Workflow, nil
+}
+
+func ParseNotificationToInvocation(update *fes.Notification) (*types.WorkflowInvocation, error) {
+	entity, ok := update.Payload.(*aggregates.WorkflowInvocation)
+	if !ok {
+		return nil, errors.New("received message does not include workflow invocation as payload")
+	}
+	return entity.WorkflowInvocation, nil
+}

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -3,12 +3,12 @@ Package apiserver contains all request handlers for gRPC and HTTP servers.
 
 It has these top-level request handlers:
 	Admin	   - Administrative functionality related to managing the workflow engine.
-	Invocation - Functionality related to managing invocations.
+	Invocation - Functionality related to managing store.
 	Workflow   - functionality related to managing workflows.
 
 The purpose of this package is purely to provide handlers to gRPC and HTTP servers. Therefore,
 it should not contain any logic (validation, composition, etc.) related to the workflows,
-invocations or any other targets that it provides. All this logic should be placed in the actual
+store or any other targets that it provides. All this logic should be placed in the actual
 packages that are responsible for the business logic, such as `api`.
 */
 package apiserver

--- a/pkg/apiserver/apiserver.pb.go
+++ b/pkg/apiserver/apiserver.pb.go
@@ -106,7 +106,7 @@ func (m *WorkflowInvocationIdentifier) GetId() string {
 }
 
 type WorkflowInvocationList struct {
-	Invocations []string `protobuf:"bytes,1,rep,name=invocations" json:"invocations,omitempty"`
+	Invocations []string `protobuf:"bytes,1,rep,name=store" json:"store,omitempty"`
 }
 
 func (m *WorkflowInvocationList) Reset()                    { *m = WorkflowInvocationList{} }

--- a/pkg/controller/invocation/controller_test.go
+++ b/pkg/controller/invocation/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/fission/fission-workflows/pkg/api"
+	"github.com/fission/fission-workflows/pkg/api/store"
 	"github.com/fission/fission-workflows/pkg/controller/expr"
 	"github.com/fission/fission-workflows/pkg/fes"
 	"github.com/fission/fission-workflows/pkg/fes/backend/mem"
@@ -30,7 +31,8 @@ func TestController_Lifecycle(t *testing.T) {
 		"mock": mockRuntime,
 	}, es, dynamicAPI)
 
-	ctr := NewController(cache, cache, s, taskAPI, wfiAPI, expr.NewStore())
+	ctr := NewController(store.NewInvocationStore(cache), store.NewWorkflowsStore(cache), s, taskAPI, wfiAPI,
+		expr.NewStore())
 
 	err := ctr.Init(context.TODO())
 	assert.NoError(t, err)

--- a/pkg/controller/workflow/controller_test.go
+++ b/pkg/controller/workflow/controller_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/fission/fission-workflows/pkg/api"
+	"github.com/fission/fission-workflows/pkg/api/store"
 	"github.com/fission/fission-workflows/pkg/fes"
 	"github.com/fission/fission-workflows/pkg/fes/backend/mem"
 	"github.com/fission/fission-workflows/pkg/fnenv"
@@ -13,14 +14,14 @@ import (
 )
 
 func TestController_Lifecycle(t *testing.T) {
-	cache := fes.NewMapCache()
+	store := store.NewWorkflowsStore(fes.NewMapCache())
 	es := mem.NewBackend()
 	mockResolver := fnenv.NewMetaResolver(map[string]fnenv.RuntimeResolver{
 		"mock": mock.NewResolver(),
 	})
 	wfAPI := api.NewWorkflowAPI(es, mockResolver)
 
-	ctr := NewController(cache, wfAPI)
+	ctr := NewController(store, wfAPI)
 
 	err := ctr.Init(context.TODO())
 	assert.NoError(t, err)

--- a/pkg/fes/types.go
+++ b/pkg/fes/types.go
@@ -64,6 +64,10 @@ type CacheReaderWriter interface {
 
 type StringMatcher func(target string) bool
 
+var (
+	DefaultNotificationBuffer = 64
+)
+
 type Notification struct {
 	*pubsub.EmptyMsg
 	Payload   Entity


### PR DESCRIPTION
Currently, all access to the workflow and invocation caches happens through the generic/untyped` fes.CacheReader` interface. This requires consumers to perform type assertions and conversions every time they need to access the caches, and makes it easy to confuse the two caches. 

This PR adds two simple wrappers on top of the fes.CacheReader interface: one for workflows, and one for invocations. These allow consumers to retrieve the workflows and invocations without the risks and verboseness of the type assertions on every access.

Before merging:
- [x] Expose pubsub.Publisher at the store-level to avoid having to expose the CacheReader interface.