### PR TITLE
Force k8s object removal in e2e cleanup

### DIFF
--- a/test/e2e/cleanup.sh
+++ b/test/e2e/cleanup.sh
@@ -28,21 +28,21 @@ cleanup_fission() {
 
     emph "Removing custom resources..."
     clean_tpr_crd_resources || true
-    kubectl delete all --all -n ${NS}
-    kubectl delete all --all -n ${NS_FUNCTION}
-    kubectl delete all --all -n ${NS_BUILDER}
+    kubectl delete all --force --now --all -n ${NS}
+    kubectl delete all --force --now --all -n ${NS_FUNCTION}
+    kubectl delete all --force --now --all -n ${NS_BUILDER}
 
 
     # Trigger deletion of all namespaces before waiting - for concurrency of deletion
     emph "Forcing deletion of namespaces..."
-    kubectl delete ns/${NS} --now > /dev/null 2>&1 # Sometimes it is not deleted by helm delete
-    kubectl delete ns/${NS_BUILDER} --now > /dev/null 2>&1 # Sometimes it is not deleted by helm delete
-    kubectl delete ns/${NS_FUNCTION} --now > /dev/null 2>&1 # Sometimes it is not deleted by helm delete
+    kubectl delete ns/${NS} --force --now > /dev/null 2>&1 # Sometimes it is not deleted by helm delete
+    kubectl delete ns/${NS_BUILDER} --force --now > /dev/null 2>&1 # Sometimes it is not deleted by helm delete
+    kubectl delete ns/${NS_FUNCTION} --force --now > /dev/null 2>&1 # Sometimes it is not deleted by helm delete
 
     # Wait until all namespaces are actually deleted!
     emph "Awaiting deletion of namespaces..."
     verify_ns_deleted() {
-        kubectl delete ns/${1} --now 2>&1  | grep -qv "Error from server (Conflict):"
+        kubectl delete ns/${1} --force --now 2>&1  | grep -qv "Error from server (Conflict):"
     }
     # Namespaces sometimes take a long time to delete for some reason
     sleep 10

--- a/test/e2e/tests/test_inputs.sh
+++ b/test/e2e/tests/test_inputs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -exuo pipefail
 
 EXAMPLE_DIR=$(dirname $0)/../../../examples/misc
 
@@ -9,7 +9,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-fission env create --name binary --image fission/binary-env:latest || true
 fission fn create --name inputs --env workflow --src ${EXAMPLE_DIR}/inputs.wf.yaml
 sleep 5 # TODO remove this once we can initiate synchronous commands
 fission fn test --name inputs -b 'foobar' -H 'HEADER_KEY: HEADER_VAL' --method PUT \


### PR DESCRIPTION
This PR aims to speed up the cleanup process (which in some cases took up the majority of the test runtime) by forcing the deletion of the kubernetes objects. This should avoid Kubernetes waiting extensively for the graceful shutdown of objects.