### PR TITLE
Improved opentracing support

### DIFF
--- a/Docs/development.md
+++ b/Docs/development.md
@@ -10,6 +10,26 @@ using [telepresence](https://telepresence.io):
 telepresence --method=vpn-tcp --namespace fission --swap-deployment workflows:workflows --expose 5555 --expose 8080
 ```
 
+### Local OpenTracing
+
+The locally running instance does not have access to the in-cluster Jaeger deployment. To view the invocations, the 
+easiest option is to run a development all-in-one Jaeger deployment locally:  
+
+```bash
+docker run -d --rm --name jaeger \
+  -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+  -p 5775:5775/udp \
+  -p 6831:6831/udp \
+  -p 6832:6832/udp \
+  -p 5778:5778 \
+  -p 16686:16686 \
+  -p 14268:14268 \
+  -p 9411:9411 \
+  jaegertracing/all-in-one:1.6
+``` 
+
+You can then navigate to `http://localhost:16686` to access the Jaeger UI.
+
 ## Testing
 
 To run local unit and integration tests:

--- a/pkg/controller/actions.go
+++ b/pkg/controller/actions.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -97,4 +98,12 @@ func (a *MultiAction) Apply() error {
 		return nil
 	}
 	return err.(error)
+}
+
+func (a *MultiAction) String() string {
+	var results []string
+	for _, action := range a.Actions {
+		results = append(results, fmt.Sprintf("%+v", action))
+	}
+	return fmt.Sprintf("%v", results)
 }

--- a/pkg/controller/evaluation_test.go
+++ b/pkg/controller/evaluation_test.go
@@ -129,7 +129,7 @@ func TestEvalCache_GetOrCreate(t *testing.T) {
 	assert.False(t, ok)
 	assert.Empty(t, es)
 
-	es = ec.LoadOrStore(id, nil)
+	es, _ = ec.LoadOrStore(id, nil)
 	assert.Equal(t, id, es.ID())
 
 	es, ok = ec.Load(id)

--- a/pkg/fnenv/native/native.go
+++ b/pkg/fnenv/native/native.go
@@ -60,7 +60,7 @@ func (fe *FunctionEnv) Invoke(spec *types.TaskInvocationSpec, opts ...fnenv.Invo
 	if !ok {
 		return nil, fmt.Errorf("could not resolve internal function '%s'", fnID)
 	}
-	span, _ := opentracing.StartSpanFromContext(cfg.Ctx, fmt.Sprintf("fnenv/internal/fn/%s", fnID))
+	span, _ := opentracing.StartSpanFromContext(cfg.Ctx, fmt.Sprintf("/fnenv/internal/%s", fnID))
 	defer span.Finish()
 	fnenv.FnActive.WithLabelValues(Name).Inc()
 	out, err := fn.Invoke(spec)

--- a/pkg/parse/parser.go
+++ b/pkg/parse/parser.go
@@ -7,6 +7,7 @@ import (
 	"github.com/fission/fission-workflows/pkg/parse/protobuf"
 	"github.com/fission/fission-workflows/pkg/parse/yaml"
 	"github.com/fission/fission-workflows/pkg/types"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -62,6 +63,7 @@ func (mp *MetaParser) ParseWith(r io.Reader, parsers ...string) (*types.Workflow
 		}
 		wf, err := p.Parse(r)
 		if err != nil {
+			logrus.WithField("parser", name).Warnf("parser failed: %v", name, err)
 			continue
 		}
 


### PR DESCRIPTION
This PR improves the opentracing support in workflows in multiple ways:
- it adds a couple of additional spans to trace: controller evaluations, fission function calls, workflow calls.
- it adds logs to spans, which include (in debug mode) all inputs, outputs and expressions.
- it adds tags to the spans, including the function references, workflow ids, task ids, and statuses, to enable searching for specific tasks.
- Adds documentation on how to use opentracing for local development.