### PR TITLE
Add default CMD and ENTRYPOINT to bundle image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -21,3 +21,12 @@ FROM scratch
 COPY --from=builder /go/src/github.com/fission/fission-workflows/fission-workflows-bundle /fission-workflows-bundle
 COPY --from=builder /go/src/github.com/fission/fission-workflows/fission-workflows-proxy /fission-workflows-proxy
 COPY --from=builder /go/src/github.com/fission/fission-workflows/fission-workflows /fission-workflows
+
+# Sensible default: run fission-workflows with in-memory event store and all basic components
+# --api - serves the gRPC and HTTP interface at :5000 and :8080 respectively
+# --internal - enables the internal function runtime
+# --controller - runs the controller and scheduler components
+# --metrics - enables Prometheus and Jaeger metric collection.
+ENTRYPOINT ["/fission-workflows-bundle"]
+
+CMD ["--api", "--internal", "--controller", "--metrics"]


### PR DESCRIPTION
The fission-workflows-bundle image has two functions: 
1) it serves as a container of all binaries of the same build. Other images use this image to grab a specific binary from it and modify it according to the use case.
2) for the plain fission workflows server, the fission-workflows-bundle is used directly.

The last use case is not as straightforward as it could be right now. To run a basic version of the workflow-engine you need to modify both the ENTRYPOINT and CMD on a `docker run`, which is cumbersome to do from the top of your head.

This PR solves this by adding a ENTRYPOINT and CMD to the Dockerfile. These are intended as sensible defaults to allow users to run an instance as simple as: `docker run -p 5555:5555 -p 8080:8080 fission/fission-workflows-bundle`. Advanced users and the Helm charts still override these settings.