### PR TITLE
Fix minor bugs in workflow parser

### DIFF
--- a/pkg/parse/parser.go
+++ b/pkg/parse/parser.go
@@ -87,6 +87,7 @@ func (mp *MetaParser) Parsers() []string {
 	var i int
 	for name := range mp.parsers {
 		ps[i] = name
+		i++
 	}
 	return ps
 }

--- a/pkg/parse/parser.go
+++ b/pkg/parse/parser.go
@@ -64,9 +64,9 @@ func (mp *MetaParser) ParseWith(r io.Reader, parsers ...string) (*types.Workflow
 		wf, err := p.Parse(r)
 		if err != nil {
 			logrus.WithField("parser", name).Warnf("parser failed: %v", err)
+			wf = nil
 			continue
 		}
-
 		result = wf
 		break
 	}


### PR DESCRIPTION
Both bugs occur when multiple parsers are being tried to parse a workflow definition. There were a couple of variables that were not updated or reset when a parser failed and another one is being tried.