### PR TITLE
Add a single gRPC client 

### DIFF
--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -15,10 +15,13 @@ package apiserver
 
 import (
 	"github.com/fission/fission-workflows/pkg/types/validate"
+	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+type Empty = empty.Empty
 
 func toErrorStatus(err error) error {
 	switch err.(type) {

--- a/pkg/apiserver/client.go
+++ b/pkg/apiserver/client.go
@@ -1,0 +1,17 @@
+package apiserver
+
+import "google.golang.org/grpc"
+
+type Client struct {
+	Admin      AdminAPIClient
+	Invocation WorkflowInvocationAPIClient
+	Workflow   WorkflowAPIClient
+}
+
+func NewClient(conn *grpc.ClientConn) *Client {
+	return &Client{
+		Admin:      NewAdminAPIClient(conn),
+		Invocation: NewWorkflowInvocationAPIClient(conn),
+		Workflow:   NewWorkflowAPIClient(conn),
+	}
+}

--- a/pkg/apiserver/client.go
+++ b/pkg/apiserver/client.go
@@ -1,11 +1,31 @@
 package apiserver
 
-import "google.golang.org/grpc"
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
 
 type Client struct {
 	Admin      AdminAPIClient
 	Invocation WorkflowInvocationAPIClient
 	Workflow   WorkflowAPIClient
+}
+
+// Await blocks until the gRPC connection has been established
+func (c *Client) Await(ctx context.Context) error {
+	var err error
+	for {
+		select {
+		case <-ctx.Done():
+			return err
+		default:
+			_, err = c.Admin.Status(ctx, &Empty{})
+			if err == nil {
+				return nil
+			}
+		}
+	}
 }
 
 func NewClient(conn *grpc.ClientConn) *Client {
@@ -14,4 +34,12 @@ func NewClient(conn *grpc.ClientConn) *Client {
 		Invocation: NewWorkflowInvocationAPIClient(conn),
 		Workflow:   NewWorkflowAPIClient(conn),
 	}
+}
+
+func Connect(addr string) (*Client, error) {
+	cc, err := grpc.Dial(addr, grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(cc), nil
 }


### PR DESCRIPTION
Although bundled together on the same server, the apiserver consists of three separate gRPC servers. This also means that we have three different generated gRPC clients. 

For convenience and clarity this PR adds a monolithic Client to the apiserver package, which wraps the three generated gRPC clients.