### PR TITLE
Add missing PullPolicy to workflow deployment

### DIFF
--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
       containers:
       - name: workflows
         image: "{{ .Values.bundleImage }}:{{.Values.tag}}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-workflows-bundle"]
         args: [
           {{- if eq .Values.eventstore.type "nats" }}


### PR DESCRIPTION
This fixes the problem that outdated images might be used in the CI environment. See #228. 