### PR TITLE
Fix Fission fn update support

### DIFF
--- a/test/e2e/tests/resources/hello.wf.yaml
+++ b/test/e2e/tests/resources/hello.wf.yaml
@@ -1,0 +1,6 @@
+apiVersion: 1
+output: Main
+tasks:
+  Main:
+    run: noop
+    inputs: "hello"

--- a/test/e2e/tests/resources/world.wf.yaml
+++ b/test/e2e/tests/resources/world.wf.yaml
@@ -1,0 +1,6 @@
+apiVersion: 1
+output: Main
+tasks:
+  Main:
+    run: noop
+    inputs: "world"

--- a/test/e2e/tests/test_fission_update.sh
+++ b/test/e2e/tests/test_fission_update.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Simple test to verify that Fission update works
+
+set -exuo pipefail
+
+FN_NAME=fw-update-test
+EXAMPLE_DIR=$(dirname $0)/../../../examples/misc
+
+cleanup() {
+    fission fn delete --name ${FN_NAME}
+}
+trap cleanup EXIT
+
+fission fn create --name ${FN_NAME} --env workflow --src $(dirname $0)/resources/hello.wf.yaml
+sleep 2
+fission fn test --name ${FN_NAME} \
+    | tee /dev/tty \
+    | grep "hello"
+
+fission fn update --name ${FN_NAME} --src $(dirname $0)/resources/world.wf.yaml
+sleep 2
+fission fn test --name ${FN_NAME} \
+    | tee /dev/tty \
+    | grep "world"


### PR DESCRIPTION
This PR addresses issue #239 - the fission fn update stopped working for workflows. This is probably caused by the complete rewrite of the Fission-Fission Workflows proxy (#221).

So far I have reproduced and added the bug. 
