### PR TITLE
Fail invocations quickly for an invalid workflow

### DIFF
--- a/test/e2e/resources/nonexistentfn.wf.yaml
+++ b/test/e2e/resources/nonexistentfn.wf.yaml
@@ -1,0 +1,6 @@
+apiVersion: 1
+output: Hello
+tasks:
+  Hello:
+    run: non-existent-fn
+    inputs: "{$.Invocation.Inputs.default}"

--- a/test/e2e/tests/test_nonexistentfn.sh
+++ b/test/e2e/tests/test_nonexistentfn.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This test checks if a invocation of a failed workflow will not hang indefinitely
+
+set -exuo pipefail
+
+FN_NAME=nonexistentfn
+EXAMPLE_DIR=$(dirname $0)/../resources/
+
+cleanup() {
+    fission fn delete --name ${FN_NAME}
+}
+trap cleanup EXIT
+
+fission fn create --name ${FN_NAME} --env workflow --src ${EXAMPLE_DIR}/nonexistentfn.wf.yaml
+
+OUT=$(! fission fn test --name ${FN_NAME} 2>&1)
+
+echo ${OUT} | grep -v "context deadline exceeded"


### PR DESCRIPTION
As mentioned by #144 - currently invocations of invalid/non-ready workflows do not fail immediately or with a clear cause.

So far, I added a minimal example reproducing the issue.