### PR TITLE
Making Jaeger Tracing image configurable

### DIFF
--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
         - name: FNENV_FISSION_EXECUTOR
           value: "{{ .Values.fission.executor }}.{{ .Values.fission.ns }}"
       - name: jaeger-agent
-        image: jaegertracing/jaeger-agent
+        image: "{{.Values.jaeger.image.repository}}:{{.Values.jaeger.image.tag}}"
         ports:
         - containerPort: 5775
           protocol: UDP

--- a/charts/fission-workflows/values.yaml
+++ b/charts/fission-workflows/values.yaml
@@ -38,4 +38,7 @@ fission:
 
 # Tracing-related configuration
 jaeger:
+  image:
+    repository: jaegertracing/jaeger-agent
+    tag: 1.16
   collector: jaeger-collector:14267


### PR DESCRIPTION
PR to fix the CrashLoopBackOff when you install the fission-workflow helm chart