### PR TITLE
Bump golang to 1.15.2

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # To run (from repo root): docker build -t fission -f ./build/Dockerfile .
-ARG GOLANG_VERSION=1.12.0
+ARG GOLANG_VERSION=1.15.2
 FROM golang:$GOLANG_VERSION AS builder
 ARG NOBUILD
 


### PR DESCRIPTION
Golang version 1.12.0 in dockerfile is now EOL, Updated to latest version 1.15