### PR TITLE
Updating container spec to include container name.

### DIFF
--- a/charts/fission-workflows/Chart.yaml
+++ b/charts/fission-workflows/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fission-workflows
-version: 0.6.0
+version: 0.6.1
 appVersion: 0.6.0
 description: Fission Workflows is a fast workflow engine for serverless functions on Kubernetes
 keywords:

--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -129,6 +129,7 @@ spec:
   runtime:
     image: "{{ .Values.fission.env.runtimeImage }}:{{.Values.tag}}"
     container:
+      name: {{ .Values.fission.env.containerName }}
       command: ["/fission-workflows-proxy"]
       imagePullPolicy: {{ .Values.pullPolicy }}
       args: [

--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -144,4 +144,5 @@ spec:
     image: "{{ .Values.fission.env.builderImage }}:{{.Values.tag}}"
     command: "defaultBuild"
     container:
+      name: {{ .Values.fission.env.containerName }}
       imagePullPolicy: {{ .Values.pullPolicy }}

--- a/charts/fission-workflows/templates/deployment.yaml
+++ b/charts/fission-workflows/templates/deployment.yaml
@@ -124,7 +124,6 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   version: 2
-  TerminationGracePeriod: 5
   allowedFunctionsPerContainer: infinite
   runtime:
     image: "{{ .Values.fission.env.runtimeImage }}:{{.Values.tag}}"

--- a/charts/fission-workflows/values.yaml
+++ b/charts/fission-workflows/values.yaml
@@ -33,6 +33,7 @@ fission:
   env:
     name: workflow
     ns: default
+    containerName: workflow
     runtimeImage: fission/workflows-proxy
     builderImage: fission/workflow-build-env
 


### PR DESCRIPTION
Fission Workflows helm chart doesn't support the latest fission specs.

Updates:
- adding container names for runtime and builder
- removed TerminationGracePeriod